### PR TITLE
Remove script references to missing directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,32 +34,6 @@ A comprehensive fleet management solution for tracking vehicles, drivers, trips,
    npm run dev
    ```
 
-### Scripts
-
-The project includes several utility scripts:
-
-#### Seed Maintenance Tasks
-
-To seed the maintenance tasks catalog:
-
-1. Navigate to the scripts directory:
-   ```
-   cd scripts
-   ```
-
-2. Install script dependencies:
-   ```
-   npm install
-   ```
-
-3. Copy `.env.example` to `.env` and fill in your Supabase credentials
-
-4. Run the seed script:
-   ```
-   npm run seed:maintenance
-   ```
-
-This will import all maintenance tasks from `src/data/maintenance_tasks.json` into the Supabase `maintenance_tasks_catalog` table.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -7,21 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "seed:vehicle": "tsx scripts/seedVehicle.ts",
-    "seed:driver": "tsx scripts/seedDriver.ts",
-    "seed:trip": "tsx scripts/seedTrip.ts",
-    "seed:trips-json": "tsx scripts/seedTripsFromJSON.ts",
-    "seed:trips-csv": "tsx scripts/seedTripsFromCSV.ts",
-    "seed:maintenance": "tsx scripts/seedMaintenanceTasks.ts",
-    "seed:maintenance-csv": "tsx scripts/seedMaintenanceFromCSV.ts",
-    "seed:vehicles-json": "tsx scripts/seedVehiclesFromJSON.ts",
-    "seed:destinations": "tsx scripts/seedDestinations.ts",
-    "seed:warehouses": "tsx scripts/seedWarehouse.ts",
-    "seed:material-types": "tsx scripts/seedMaterialTypes.ts",
-    "fetch:drivers": "tsx scripts/fetchDrivers.ts",
-    "clean:db": "tsx scripts/clean-database.ts",
-    "delete:alerts": "tsx scripts/delete-ai-alerts.ts"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.16.2",


### PR DESCRIPTION
## Summary
- prune broken script commands from `package.json`
- remove obsolete README instructions referencing `scripts/`

## Testing
- `npm run lint` *(fails: 360 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cba75b3888324bd4eb24b45bb68dc