### PR TITLE
Fix duplicate sort in TripList

### DIFF
--- a/src/components/trips/TripList.tsx
+++ b/src/components/trips/TripList.tsx
@@ -63,8 +63,10 @@ const TripList: React.FC<TripListProps> = ({
         
         return true;
       })
-      .sort((a, b) => new Date(b.trip_start_date || 0).getTime() - new Date(a.trip_start_date || 0).getTime())
-      .sort((a, b) => new Date(b.trip_start_date || 0).getTime() - new Date(a.trip_start_date || 0).getTime())
+      .sort((a, b) =>
+        new Date(b.trip_start_date || 0).getTime() -
+        new Date(a.trip_start_date || 0).getTime()
+      )
     : [];
   }, [trips, searchTerm, filterVehicle, filterDriver, filterRefueling, vehicles, drivers]);
   


### PR DESCRIPTION
## Summary
- remove redundant sort call in `TripList`

## Testing
- `npm install`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686cc1ed8ab483249c7e95ae1abdd8ec