### PR TITLE
Implement debounced place search

### DIFF
--- a/src/components/admin/WarehouseForm.tsx
+++ b/src/components/admin/WarehouseForm.tsx
@@ -5,7 +5,7 @@ import Input from '../ui/Input';
 import Select from '../ui/Select';
 import Button from '../ui/Button';
 import { Loader } from '@googlemaps/js-api-loader';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { getMaterialTypes, MaterialType } from '../../utils/materialTypes'; // Import MaterialType
 
 interface WarehouseFormData {
@@ -75,32 +75,37 @@ const WarehouseForm: React.FC<WarehouseFormProps> = ({
     fetchMaterials();
   }, []);
 
-  // Handle search input changes
+  // Search handler wrapped in a callback for debounce
+  const handleSearch = useCallback(async () => {
+    if (!autocompleteService || searchTerm.length < 2) {
+      setPredictions([]);
+      return;
+    }
+
+    try {
+      const response = await autocompleteService.getPlacePredictions({
+        input: searchTerm,
+        types: ['(cities)'],
+        componentRestrictions: { country: 'in' }
+      });
+
+      if (response && response.predictions) {
+        setPredictions(response.predictions);
+      }
+    } catch (error) {
+      console.error('Error getting place predictions:', error);
+      setPredictions([]);
+    }
+  }, [autocompleteService, searchTerm]);
+
+  // Debounce search calls when the user types
   useEffect(() => {
-    const handleSearch = async () => {
-      if (!autocompleteService || searchTerm.length < 2) {
-        setPredictions([]);
-        return;
-      }
+    const timeoutId = setTimeout(() => {
+      handleSearch();
+    }, 300);
 
-      try {
-        const response = await autocompleteService.getPlacePredictions({
-          input: searchTerm,
-          types: ['(cities)'],
-          componentRestrictions: { country: 'in' }
-        });
-
-        if (response && response.predictions) {
-          setPredictions(response.predictions);
-        }
-      } catch (error) {
-        console.error('Error getting place predictions:', error);
-        setPredictions([]);
-      }
-    };
-
-    handleSearch();
-  }, [searchTerm, autocompleteService]);
+    return () => clearTimeout(timeoutId);
+  }, [handleSearch]);
 
   const handleSelectPlace = async (prediction: google.maps.places.AutocompletePrediction) => {
     if (!placesService) return;


### PR DESCRIPTION
## Summary
- debounce Google place search in WarehouseForm to avoid extra API calls

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686cc1fe24c48324a8649a97312596f9