### PR TITLE
Cache Google Maps Loader

### DIFF
--- a/src/components/admin/WarehouseForm.tsx
+++ b/src/components/admin/WarehouseForm.tsx
@@ -4,7 +4,7 @@ import { Building2, MapPin, Search } from 'lucide-react';
 import Input from '../ui/Input';
 import Select from '../ui/Select';
 import Button from '../ui/Button';
-import { Loader } from '@googlemaps/js-api-loader';
+import { loadGoogleMaps } from '../../utils/googleMapsLoader';
 import { useState, useEffect, useRef } from 'react';
 import { getMaterialTypes, MaterialType } from '../../utils/materialTypes'; // Import MaterialType
 
@@ -43,24 +43,18 @@ const WarehouseForm: React.FC<WarehouseFormProps> = ({
 
   // Initialize Google Maps services
   useEffect(() => {
-    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
-    
-    const loader = new Loader({
-      apiKey,
-      version: 'weekly',
-      libraries: ['places']
-    });
+    loadGoogleMaps()
+      .then(() => {
+        setAutocompleteService(new google.maps.places.AutocompleteService());
 
-    loader.load().then(() => {
-      setAutocompleteService(new google.maps.places.AutocompleteService());
-      
-      // Create a dummy div for PlacesService (required)
-      if (placesRef.current) {
-        setPlacesService(new google.maps.places.PlacesService(placesRef.current));
-      }
-    }).catch(err => {
-      console.error('Error loading Google Maps:', err);
-    });
+        // Create a dummy div for PlacesService (required)
+        if (placesRef.current) {
+          setPlacesService(new google.maps.places.PlacesService(placesRef.current));
+        }
+      })
+      .catch(err => {
+        console.error('Error loading Google Maps:', err);
+      });
 
     // Fetch material types
     const fetchMaterials = async () => {

--- a/src/utils/googleMapsLoader.ts
+++ b/src/utils/googleMapsLoader.ts
@@ -1,0 +1,24 @@
+import { Loader } from '@googlemaps/js-api-loader';
+
+const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
+if (!GOOGLE_MAPS_API_KEY) {
+  throw new Error('Google Maps API key is missing');
+}
+
+const loader = new Loader({
+  apiKey: GOOGLE_MAPS_API_KEY,
+  version: 'weekly',
+  libraries: ['places']
+});
+
+let loadPromise: Promise<typeof google> | null = null;
+
+export const loadGoogleMaps = (): Promise<typeof google> => {
+  if (!loadPromise) {
+    loadPromise = loader.load();
+  }
+  return loadPromise;
+};
+
+export { loader };

--- a/src/utils/routeOptimizer.ts
+++ b/src/utils/routeOptimizer.ts
@@ -1,5 +1,5 @@
 import { Warehouse, Destination } from '../types';
-import { Loader } from '@googlemaps/js-api-loader';
+import { loadGoogleMaps } from './googleMapsLoader';
 
 const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
@@ -94,13 +94,7 @@ const optimizeRoute = async (
   }
 
   try {
-    const loader = new Loader({
-      apiKey: GOOGLE_MAPS_API_KEY,
-      version: 'weekly',
-      libraries: ['places']
-    });
-
-    await loader.load();
+    await loadGoogleMaps();
 
     const service = new google.maps.DirectionsService();
 


### PR DESCRIPTION
## Summary
- cache the Google Maps loader in a shared module
- reuse loader in WarehouseForm
- reuse loader in route optimizer

## Testing
- `npm run lint` *(fails: 353 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cc20023108324ae1cdaf7602c0b96