### PR TITLE
Fix path aliases

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { resolve } from "path";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src')
+    }
+  },
   optimizeDeps: {
     include: ["react", "react-dom", "recharts"],
   },


### PR DESCRIPTION
## Summary
- add `@` alias to src in Vite
- configure TypeScript paths

## Testing
- `npm run lint` *(fails: cannot resolve many TypeScript and lint issues)*
- `npm run build`
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cd02768f883248ae8dfcdcf6da2cd