### PR TITLE
Add checks for driver utilization metrics

### DIFF
--- a/src/pages/drivers/DriverInsightsPage.tsx
+++ b/src/pages/drivers/DriverInsightsPage.tsx
@@ -1,27 +1,37 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
-import Layout from '../../components/layout/Layout';
-import { 
-  BarChart2, 
-  ChevronLeft, 
-  IndianRupee, 
-  TrendingUp, 
-  Calendar, 
+import React, { useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import Layout from "../../components/layout/Layout";
+import {
+  BarChart2,
+  ChevronLeft,
+  IndianRupee,
+  TrendingUp,
+  Calendar,
   Filter,
   Search,
   Download,
   RefreshCw,
   User,
   Fuel,
-  Users
-} from 'lucide-react';
-import Button from '../../components/ui/Button';
-import Input from '../../components/ui/Input';
-import Select from '../../components/ui/Select';
-import StatCard from '../../components/ui/StatCard';
-import { getDrivers, getTrips, getVehicles } from '../../utils/storage';
-import { format, parseISO, isValid, subMonths, startOfMonth, endOfMonth } from 'date-fns';
-import { Driver, Trip, Vehicle } from '../../types';
+  Users,
+  Package,
+  Gauge,
+} from "lucide-react";
+import Button from "../../components/ui/Button";
+import Input from "../../components/ui/Input";
+import Select from "../../components/ui/Select";
+import StatCard from "../../components/ui/StatCard";
+import { getDrivers, getTrips, getVehicles } from "../../utils/storage";
+import {
+  format,
+  parseISO,
+  isValid,
+  subMonths,
+  startOfMonth,
+  endOfMonth,
+  differenceInDays,
+} from "date-fns";
+import { Driver, Trip, Vehicle } from "../../types";
 import {
   BarChart,
   Bar,
@@ -32,11 +42,11 @@ import {
   ResponsiveContainer,
   Cell,
   LineChart,
-  Line
-} from 'recharts';
-import { toast } from 'react-toastify';
-import * as XLSX from 'xlsx';
-import { saveAs } from 'file-saver';
+  Line,
+} from "recharts";
+import { toast } from "react-toastify";
+import * as XLSX from "xlsx";
+import { saveAs } from "file-saver";
 
 // Interface for driver performance metrics
 interface DriverPerformance {
@@ -48,6 +58,10 @@ interface DriverPerformance {
   avgMileage: number;
   totalExpenses: number;
   costPerKm: number;
+  totalGrossWeight: number;
+  tripDays: Set<string>;
+  avgLoadPerTrip: number;
+  driverUtilizationPercentage: number;
   lastTripDate: string | null;
 }
 
@@ -58,13 +72,15 @@ const DriverInsightsPage: React.FC = () => {
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [loading, setLoading] = useState(true);
   const [exportLoading, setExportLoading] = useState(false);
-  
+
   // Filters
-  const [dateRange, setDateRange] = useState<'thisMonth' | 'lastThreeMonths' | 'lastSixMonths' | 'lastYear' | 'allTime'>('lastThreeMonths');
-  const [selectedDriver, setSelectedDriver] = useState<string>('all');
-  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [dateRange, setDateRange] = useState<
+    "thisMonth" | "lastThreeMonths" | "lastSixMonths" | "lastYear" | "allTime"
+  >("lastThreeMonths");
+  const [selectedDriver, setSelectedDriver] = useState<string>("all");
+  const [searchTerm, setSearchTerm] = useState<string>("");
   const [showFilters, setShowFilters] = useState(true);
-  
+
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
@@ -72,82 +88,86 @@ const DriverInsightsPage: React.FC = () => {
         const [driversData, tripsData, vehiclesData] = await Promise.all([
           getDrivers(),
           getTrips(),
-          getVehicles()
+          getVehicles(),
         ]);
-        
+
         setDrivers(driversData);
         setTrips(tripsData);
         setVehicles(vehiclesData);
       } catch (error) {
-        console.error('Error fetching data:', error);
-        toast.error('Failed to load driver analytics data');
+        console.error("Error fetching data:", error);
+        toast.error("Failed to load driver analytics data");
       } finally {
         setLoading(false);
       }
     };
-    
+
     fetchData();
   }, []);
-  
+
   // Calculate date range based on filter
   const effectiveDateRange = useMemo(() => {
     const now = new Date();
-    
+
     switch (dateRange) {
-      case 'thisMonth':
+      case "thisMonth":
         return {
           start: startOfMonth(now),
-          end: now
+          end: now,
         };
-      case 'lastThreeMonths':
+      case "lastThreeMonths":
         return {
           start: subMonths(now, 3),
-          end: now
+          end: now,
         };
-      case 'lastSixMonths':
+      case "lastSixMonths":
         return {
           start: subMonths(now, 6),
-          end: now
+          end: now,
         };
-      case 'lastYear':
+      case "lastYear":
         return {
           start: subMonths(now, 12),
-          end: now
+          end: now,
         };
-      case 'allTime':
+      case "allTime":
         return {
           start: new Date(0), // January 1, 1970
-          end: now
+          end: now,
         };
     }
   }, [dateRange]);
-  
+
   // Filter trips based on date range and driver selection
   const filteredTrips = useMemo(() => {
-    return trips.filter(trip => {
+    return trips.filter((trip) => {
       // Filter by date
       const tripDate = parseISO(trip.trip_start_date);
-      if (!isValid(tripDate) || tripDate < effectiveDateRange.start || tripDate > effectiveDateRange.end) {
+      if (
+        !isValid(tripDate) ||
+        tripDate < effectiveDateRange.start ||
+        tripDate > effectiveDateRange.end
+      ) {
         return false;
       }
-      
+
       // Filter by driver if selected
-      if (selectedDriver !== 'all' && trip.driver_id !== selectedDriver) {
+      if (selectedDriver !== "all" && trip.driver_id !== selectedDriver) {
         return false;
       }
-      
+
       return true;
     });
   }, [trips, effectiveDateRange, selectedDriver]);
-  
+
   // Calculate driver performance metrics
   const driverPerformance = useMemo(() => {
     const performanceMap = new Map<string, DriverPerformance>();
-    
+
     // Initialize with all drivers (even those with no trips)
-    drivers.forEach(driver => {
-      performanceMap.set(driver.id || '', {
-        driverId: driver.id || '',
+    drivers.forEach((driver) => {
+      performanceMap.set(driver.id || "", {
+        driverId: driver.id || "",
         name: driver.name,
         totalTrips: 0,
         totalDistance: 0,
@@ -155,135 +175,196 @@ const DriverInsightsPage: React.FC = () => {
         avgMileage: 0,
         totalExpenses: 0,
         costPerKm: 0,
-        lastTripDate: null
+        totalGrossWeight: 0,
+        tripDays: new Set<string>(),
+        avgLoadPerTrip: 0,
+        driverUtilizationPercentage: 0,
+        lastTripDate: null,
       });
     });
-    
+
     // Process filtered trips
-    filteredTrips.forEach(trip => {
+    filteredTrips.forEach((trip) => {
       const driverId = trip.driver_id;
       if (!driverId) return;
-      
+
       const performance = performanceMap.get(driverId) || {
         driverId,
-        name: drivers.find(d => d.id === driverId)?.name || 'Unknown',
+        name: drivers.find((d) => d.id === driverId)?.name || "Unknown",
         totalTrips: 0,
         totalDistance: 0,
         totalFuel: 0,
         avgMileage: 0,
         totalExpenses: 0,
         costPerKm: 0,
-        lastTripDate: null
+        totalGrossWeight: 0,
+        tripDays: new Set<string>(),
+        avgLoadPerTrip: 0,
+        driverUtilizationPercentage: 0,
+        lastTripDate: null,
       };
-      
+
       const distance = trip.end_km - trip.start_km;
       const fuel = trip.fuel_quantity || 0;
-      const expenses = (trip.total_fuel_cost || 0) + (trip.total_road_expenses || 0);
-      
+      const expenses =
+        (trip.total_fuel_cost || 0) + (trip.total_road_expenses || 0);
+      const grossWeight = trip.gross_weight || 0;
+      const tripStart = trip.trip_start_date
+        ? trip.trip_start_date.slice(0, 10)
+        : null;
+
       // Update metrics
       performance.totalTrips++;
       performance.totalDistance += distance;
       performance.totalFuel += fuel;
       performance.totalExpenses += expenses;
-      
+      performance.totalGrossWeight += grossWeight;
+      if (tripStart) {
+        performance.tripDays.add(tripStart);
+      }
+
       // Update last trip date if newer
       const tripDate = trip.trip_end_date;
-      if (tripDate && (!performance.lastTripDate || tripDate > performance.lastTripDate)) {
+      if (
+        tripDate &&
+        (!performance.lastTripDate || tripDate > performance.lastTripDate)
+      ) {
         performance.lastTripDate = tripDate;
       }
-      
+
       performanceMap.set(driverId, performance);
     });
-    
+
     // Calculate derived metrics
-    performanceMap.forEach(performance => {
+    performanceMap.forEach((performance) => {
       if (performance.totalFuel > 0) {
-        performance.avgMileage = performance.totalDistance / performance.totalFuel;
+        performance.avgMileage =
+          performance.totalDistance / performance.totalFuel;
       }
-      
+
       if (performance.totalDistance > 0) {
-        performance.costPerKm = performance.totalExpenses / performance.totalDistance;
+        performance.costPerKm =
+          performance.totalExpenses / performance.totalDistance;
       }
+
+      performance.avgLoadPerTrip =
+        performance.totalTrips > 0
+          ? performance.totalGrossWeight / performance.totalTrips
+          : 0;
+      const totalDaysInPeriod =
+        differenceInDays(effectiveDateRange.end, effectiveDateRange.start) + 1;
+      performance.driverUtilizationPercentage =
+        totalDaysInPeriod > 0
+          ? (performance.tripDays.size / totalDaysInPeriod) * 100
+          : 0;
     });
-    
+
     // Convert to array and filter by search term
     return Array.from(performanceMap.values())
-      .filter(performance => {
+      .filter((performance) => {
         if (!searchTerm) return true;
         const lowerSearch = searchTerm.toLowerCase();
         return performance.name.toLowerCase().includes(lowerSearch);
       })
       .sort((a, b) => b.totalTrips - a.totalTrips);
   }, [drivers, filteredTrips, searchTerm]);
-  
+
   // Calculate summary metrics
   const summaryMetrics = useMemo(() => {
     const totalDrivers = drivers.length;
-    const activeDrivers = driverPerformance.filter(p => p.totalTrips > 0).length;
-    
+    const activeDrivers = driverPerformance.filter(
+      (p) => p.totalTrips > 0,
+    ).length;
+
     let totalDistance = 0;
     let totalFuel = 0;
     let totalExpenses = 0;
-    
-    driverPerformance.forEach(p => {
+    let avgLoadPerTripSum = 0;
+    let utilizationSum = 0;
+
+    driverPerformance.forEach((p) => {
       totalDistance += p.totalDistance;
       totalFuel += p.totalFuel;
       totalExpenses += p.totalExpenses;
+      avgLoadPerTripSum += p.avgLoadPerTrip || 0;
+      utilizationSum += p.driverUtilizationPercentage || 0;
     });
-    
-    const avgKmPerDay = totalDistance / (
-      Math.max(1, Math.round((effectiveDateRange.end.getTime() - effectiveDateRange.start.getTime()) / (1000 * 60 * 60 * 24)))
-    );
-    
+
+    const avgKmPerDay =
+      totalDistance /
+      Math.max(
+        1,
+        Math.round(
+          (effectiveDateRange.end.getTime() -
+            effectiveDateRange.start.getTime()) /
+            (1000 * 60 * 60 * 24),
+        ),
+      );
+
     const avgCostPerKm = totalDistance > 0 ? totalExpenses / totalDistance : 0;
-    
+
+    const avgLoadPerTrip =
+      driverPerformance.length > 0
+        ? avgLoadPerTripSum / driverPerformance.length
+        : 0;
+    const avgDriverUtilization =
+      driverPerformance.length > 0
+        ? utilizationSum / driverPerformance.length
+        : 0;
+
     // Find top performing driver
-    const topDriver = driverPerformance.length > 0 
-      ? [...driverPerformance]
-        .filter(p => p.totalTrips > 0)
-        .sort((a, b) => a.costPerKm - b.costPerKm)[0]
-      : null;
-    
+    const topDriver =
+      driverPerformance.length > 0
+        ? [...driverPerformance]
+            .filter((p) => p.totalTrips > 0)
+            .sort((a, b) => a.costPerKm - b.costPerKm)[0]
+        : null;
+
     return {
       totalDrivers,
       activeDrivers,
       avgKmPerDay,
       avgCostPerKm,
-      topDriver
+      avgLoadPerTrip,
+      avgDriverUtilization,
+      topDriver,
     };
   }, [drivers, driverPerformance, effectiveDateRange]);
-  
+
   // Monthly performance data for charts
   const monthlyPerformanceData = useMemo(() => {
-    const monthlyData: Record<string, { 
-      month: string, 
-      totalDistance: number, 
-      totalFuel: number,
-      driverCount: number
-    }> = {};
-    
-    filteredTrips.forEach(trip => {
+    const monthlyData: Record<
+      string,
+      {
+        month: string;
+        totalDistance: number;
+        totalFuel: number;
+        driverCount: number;
+      }
+    > = {};
+
+    filteredTrips.forEach((trip) => {
       const tripDate = parseISO(trip.trip_start_date);
       if (!isValid(tripDate)) return;
-      
-      const monthKey = format(tripDate, 'MMM yyyy');
-      
+
+      const monthKey = format(tripDate, "MMM yyyy");
+
       if (!monthlyData[monthKey]) {
         monthlyData[monthKey] = {
           month: monthKey,
           totalDistance: 0,
           totalFuel: 0,
-          driverCount: 0
+          driverCount: 0,
         };
       }
-      
-      monthlyData[monthKey].totalDistance += (trip.end_km - trip.start_km);
-      monthlyData[monthKey].totalFuel += (trip.fuel_quantity || 0);
-      
+
+      monthlyData[monthKey].totalDistance += trip.end_km - trip.start_km;
+      monthlyData[monthKey].totalFuel += trip.fuel_quantity || 0;
+
       // Count unique drivers
       const uniqueDrivers = new Set<string>();
-      Object.values(monthlyData).forEach(data => {
-        filteredTrips.forEach(trip => {
+      Object.values(monthlyData).forEach((data) => {
+        filteredTrips.forEach((trip) => {
           if (trip.driver_id) {
             uniqueDrivers.add(trip.driver_id);
           }
@@ -291,45 +372,55 @@ const DriverInsightsPage: React.FC = () => {
       });
       monthlyData[monthKey].driverCount = uniqueDrivers.size;
     });
-    
+
     // Convert to array and sort by date
     return Object.values(monthlyData).sort((a, b) => {
       return new Date(a.month).getTime() - new Date(b.month).getTime();
     });
   }, [filteredTrips]);
-  
+
   // Export data to Excel
   const handleExport = () => {
     setExportLoading(true);
     try {
-      const exportData = driverPerformance.map(driver => ({
-        'Driver Name': driver.name,
-        'Total Trips': driver.totalTrips,
-        'Total Distance (km)': driver.totalDistance.toFixed(0),
-        'Total Fuel (L)': driver.totalFuel.toFixed(2),
-        'Avg Mileage (km/L)': driver.avgMileage.toFixed(2),
-        'Total Expenses (₹)': driver.totalExpenses.toFixed(2),
-        'Cost per KM (₹)': driver.costPerKm.toFixed(2),
-        'Last Trip Date': driver.lastTripDate ? new Date(driver.lastTripDate).toLocaleDateString() : 'N/A'
+      const exportData = driverPerformance.map((driver) => ({
+        "Driver Name": driver.name,
+        "Total Trips": driver.totalTrips,
+        "Total Distance (km)": driver.totalDistance.toFixed(0),
+        "Total Fuel (L)": driver.totalFuel.toFixed(2),
+        "Avg Mileage (km/L)": driver.avgMileage.toFixed(2),
+        "Total Expenses (₹)": driver.totalExpenses.toFixed(2),
+        "Cost per KM (₹)": driver.costPerKm.toFixed(2),
+        "Last Trip Date": driver.lastTripDate
+          ? new Date(driver.lastTripDate).toLocaleDateString()
+          : "N/A",
       }));
-      
+
       const worksheet = XLSX.utils.json_to_sheet(exportData);
       const workbook = XLSX.utils.book_new();
-      XLSX.utils.book_append_sheet(workbook, worksheet, 'Driver Performance');
-      
-      const excelBuffer = XLSX.write(workbook, { bookType: 'xlsx', type: 'array' });
-      const blob = new Blob([excelBuffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-      
-      saveAs(blob, `Driver_Performance_${format(new Date(), 'yyyy-MM-dd')}.xlsx`);
-      toast.success('Export successful');
+      XLSX.utils.book_append_sheet(workbook, worksheet, "Driver Performance");
+
+      const excelBuffer = XLSX.write(workbook, {
+        bookType: "xlsx",
+        type: "array",
+      });
+      const blob = new Blob([excelBuffer], {
+        type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      });
+
+      saveAs(
+        blob,
+        `Driver_Performance_${format(new Date(), "yyyy-MM-dd")}.xlsx`,
+      );
+      toast.success("Export successful");
     } catch (error) {
-      console.error('Export error:', error);
-      toast.error('Failed to export data');
+      console.error("Export error:", error);
+      toast.error("Failed to export data");
     } finally {
       setExportLoading(false);
     }
   };
-  
+
   return (
     <Layout
       title="Driver Insights"
@@ -338,12 +429,12 @@ const DriverInsightsPage: React.FC = () => {
         <div className="flex flex-wrap gap-3">
           <Button
             variant="outline"
-            onClick={() => navigate('/drivers')}
+            onClick={() => navigate("/drivers")}
             icon={<ChevronLeft className="h-4 w-4" />}
           >
             Back to Drivers
           </Button>
-          
+
           <Button
             variant="outline"
             onClick={handleExport}
@@ -364,34 +455,59 @@ const DriverInsightsPage: React.FC = () => {
       ) : (
         <div className="space-y-6">
           {/* Summary Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
             <StatCard
               title="Total Drivers"
               value={summaryMetrics.totalDrivers}
               icon={<Users className="h-5 w-5 text-primary-600" />}
             />
-            
+
             <StatCard
               title="Average KM/Day"
               value={Math.round(summaryMetrics.avgKmPerDay)}
               subtitle="km"
               icon={<Calendar className="h-5 w-5 text-primary-600" />}
             />
-            
+
             <StatCard
               title="Average Cost/KM"
               value={`₹${summaryMetrics.avgCostPerKm.toFixed(2)}`}
               icon={<IndianRupee className="h-5 w-5 text-primary-600" />}
             />
-            
+
+            <StatCard
+              title="Avg Load/Trip"
+              value={
+                summaryMetrics.avgLoadPerTrip
+                  ? summaryMetrics.avgLoadPerTrip.toFixed(1)
+                  : "0"
+              }
+              subtitle="tons"
+              icon={<Package className="h-5 w-5 text-primary-600" />}
+            />
+
+            <StatCard
+              title="Driver Utilization"
+              value={
+                summaryMetrics.avgDriverUtilization
+                  ? `${summaryMetrics.avgDriverUtilization.toFixed(1)}%`
+                  : "0%"
+              }
+              icon={<Gauge className="h-5 w-5 text-primary-600" />}
+            />
+
             <StatCard
               title="Top Performing Driver"
-              value={summaryMetrics.topDriver?.name || 'N/A'}
-              subtitle={summaryMetrics.topDriver ? `₹${summaryMetrics.topDriver.costPerKm.toFixed(2)}/km` : undefined}
+              value={summaryMetrics.topDriver?.name || "N/A"}
+              subtitle={
+                summaryMetrics.topDriver
+                  ? `₹${summaryMetrics.topDriver.costPerKm.toFixed(2)}/km`
+                  : undefined
+              }
               icon={<User className="h-5 w-5 text-primary-600" />}
             />
           </div>
-          
+
           {/* Filters */}
           <div className="bg-white p-4 rounded-lg shadow-sm">
             <div className="flex flex-wrap gap-4 justify-between">
@@ -401,44 +517,44 @@ const DriverInsightsPage: React.FC = () => {
                   Filters
                 </h2>
               </div>
-              
+
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => setShowFilters(!showFilters)}
               >
-                {showFilters ? 'Hide Filters' : 'Show Filters'}
+                {showFilters ? "Hide Filters" : "Show Filters"}
               </Button>
             </div>
-            
+
             {showFilters && (
               <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
                 <Select
                   label="Time Period"
                   options={[
-                    { value: 'thisMonth', label: 'This Month' },
-                    { value: 'lastThreeMonths', label: 'Last 3 Months' },
-                    { value: 'lastSixMonths', label: 'Last 6 Months' },
-                    { value: 'lastYear', label: 'Last 12 Months' },
-                    { value: 'allTime', label: 'All Time' }
+                    { value: "thisMonth", label: "This Month" },
+                    { value: "lastThreeMonths", label: "Last 3 Months" },
+                    { value: "lastSixMonths", label: "Last 6 Months" },
+                    { value: "lastYear", label: "Last 12 Months" },
+                    { value: "allTime", label: "All Time" },
                   ]}
                   value={dateRange}
                   onChange={(e) => setDateRange(e.target.value as any)}
                 />
-                
+
                 <Select
                   label="Driver"
                   options={[
-                    { value: 'all', label: 'All Drivers' },
-                    ...drivers.map(driver => ({
-                      value: driver.id || '',
-                      label: driver.name
-                    }))
+                    { value: "all", label: "All Drivers" },
+                    ...drivers.map((driver) => ({
+                      value: driver.id || "",
+                      label: driver.name,
+                    })),
                   ]}
                   value={selectedDriver}
                   onChange={(e) => setSelectedDriver(e.target.value)}
                 />
-                
+
                 <Input
                   label="Search"
                   placeholder="Search drivers..."
@@ -449,70 +565,100 @@ const DriverInsightsPage: React.FC = () => {
               </div>
             )}
           </div>
-          
+
           {/* Driver Performance Table */}
           <div className="bg-white rounded-lg shadow-sm overflow-hidden">
             <div className="px-4 py-5 border-b border-gray-200 sm:px-6 flex items-center justify-between">
               <div>
-                <h3 className="text-lg leading-6 font-medium text-gray-900">Driver Performance</h3>
+                <h3 className="text-lg leading-6 font-medium text-gray-900">
+                  Driver Performance
+                </h3>
                 <p className="mt-1 text-sm text-gray-500">
-                  Showing {driverPerformance.filter(d => d.totalTrips > 0).length} active drivers
+                  Showing{" "}
+                  {driverPerformance.filter((d) => d.totalTrips > 0).length}{" "}
+                  active drivers
                 </p>
               </div>
-              
+
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => {
-                  setDateRange('lastThreeMonths');
-                  setSelectedDriver('all');
-                  setSearchTerm('');
+                  setDateRange("lastThreeMonths");
+                  setSelectedDriver("all");
+                  setSearchTerm("");
                 }}
                 icon={<RefreshCw className="h-4 w-4" />}
               >
                 Reset Filters
               </Button>
             </div>
-            
+
             <div className="overflow-x-auto">
-              {driverPerformance.filter(d => d.totalTrips > 0).length > 0 ? (
+              {driverPerformance.filter((d) => d.totalTrips > 0).length > 0 ? (
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
                         Driver
                       </th>
-                      <th scope="col" className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
                         Total Trips
                       </th>
-                      <th scope="col" className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
                         Distance
                       </th>
-                      <th scope="col" className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
                         Fuel
                       </th>
-                      <th scope="col" className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
                         Mileage
                       </th>
-                      <th scope="col" className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
                         Total Expenses
                       </th>
-                      <th scope="col" className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
                         Cost per KM
                       </th>
-                      <th scope="col" className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
                         Last Trip
                       </th>
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
                     {driverPerformance
-                      .filter(driver => driver.totalTrips > 0)
-                      .map(driver => (
-                        <tr 
-                          key={driver.driverId} 
+                      .filter((driver) => driver.totalTrips > 0)
+                      .map((driver) => (
+                        <tr
+                          key={driver.driverId}
                           className="hover:bg-gray-50 cursor-pointer"
-                          onClick={() => navigate(`/drivers/${driver.driverId}`)}
+                          onClick={() =>
+                            navigate(`/drivers/${driver.driverId}`)
+                          }
                         >
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="flex items-center">
@@ -520,8 +666,12 @@ const DriverInsightsPage: React.FC = () => {
                                 <User className="h-6 w-6 text-gray-400" />
                               </div>
                               <div className="ml-4">
-                                <div className="text-sm font-medium text-gray-900">{driver.name}</div>
-                                <div className="text-xs text-gray-500">ID: {driver.driverId.slice(0, 8)}...</div>
+                                <div className="text-sm font-medium text-gray-900">
+                                  {driver.name}
+                                </div>
+                                <div className="text-xs text-gray-500">
+                                  ID: {driver.driverId.slice(0, 8)}...
+                                </div>
                               </div>
                             </div>
                           </td>
@@ -535,42 +685,63 @@ const DriverInsightsPage: React.FC = () => {
                             {driver.totalFuel.toFixed(2)} L
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-center">
-                            {driver.avgMileage > 0 ? `${driver.avgMileage.toFixed(2)} km/L` : '-'}
+                            {driver.avgMileage > 0
+                              ? `${driver.avgMileage.toFixed(2)} km/L`
+                              : "-"}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-center">
-                            ₹{driver.totalExpenses.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                            ₹
+                            {driver.totalExpenses.toLocaleString(undefined, {
+                              maximumFractionDigits: 0,
+                            })}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-center font-medium">
-                            <span className={driver.costPerKm < 10 ? 'text-green-600' : driver.costPerKm < 15 ? 'text-amber-600' : 'text-red-600'}>
+                            <span
+                              className={
+                                driver.costPerKm < 10
+                                  ? "text-green-600"
+                                  : driver.costPerKm < 15
+                                    ? "text-amber-600"
+                                    : "text-red-600"
+                              }
+                            >
                               ₹{driver.costPerKm.toFixed(2)}
                             </span>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-center">
-                            {driver.lastTripDate ? format(new Date(driver.lastTripDate), 'dd MMM yyyy') : '-'}
+                            {driver.lastTripDate
+                              ? format(
+                                  new Date(driver.lastTripDate),
+                                  "dd MMM yyyy",
+                                )
+                              : "-"}
                           </td>
                         </tr>
-                      ))
-                    }
+                      ))}
                   </tbody>
                 </table>
               ) : (
                 <div className="text-center py-16 bg-gray-50">
                   <User className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900">No driver activity found</h3>
+                  <h3 className="text-lg font-medium text-gray-900">
+                    No driver activity found
+                  </h3>
                   <p className="mt-2 text-gray-500">
-                    {searchTerm ? 
-                      `No drivers matching "${searchTerm}" have recorded trips.` : 
-                      'No drivers have recorded trips in the selected time period.'}
+                    {searchTerm
+                      ? `No drivers matching "${searchTerm}" have recorded trips.`
+                      : "No drivers have recorded trips in the selected time period."}
                   </p>
                 </div>
               )}
             </div>
           </div>
-          
+
           {/* Charts */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <div className="bg-white p-6 rounded-lg shadow-sm">
-              <h3 className="text-lg font-medium text-gray-900 mb-4">Distance Trend</h3>
+              <h3 className="text-lg font-medium text-gray-900 mb-4">
+                Distance Trend
+              </h3>
               <div className="h-80">
                 {monthlyPerformanceData.length > 0 ? (
                   <ResponsiveContainer width="100%" height="100%">
@@ -579,15 +750,17 @@ const DriverInsightsPage: React.FC = () => {
                       margin={{ top: 5, right: 30, left: 20, bottom: 25 }}
                     >
                       <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                      <XAxis 
-                        dataKey="month" 
-                        tick={{ angle: -45, textAnchor: 'end', fontSize: 12 }}
+                      <XAxis
+                        dataKey="month"
+                        tick={{ angle: -45, textAnchor: "end", fontSize: 12 }}
                         height={60}
                         tickMargin={10}
                       />
-                      <YAxis 
+                      <YAxis
                         yAxisId="left"
-                        tickFormatter={(value) => `${value.toLocaleString()} km`}
+                        tickFormatter={(value) =>
+                          `${value.toLocaleString()} km`
+                        }
                       />
                       <Tooltip />
                       <Line
@@ -609,46 +782,69 @@ const DriverInsightsPage: React.FC = () => {
                 )}
               </div>
             </div>
-            
+
             <div className="bg-white p-6 rounded-lg shadow-sm">
-              <h3 className="text-lg font-medium text-gray-900 mb-4">Driver Performance Comparison</h3>
+              <h3 className="text-lg font-medium text-gray-900 mb-4">
+                Driver Performance Comparison
+              </h3>
               <div className="h-80">
-                {driverPerformance.filter(d => d.totalTrips > 0).length > 0 ? (
+                {driverPerformance.filter((d) => d.totalTrips > 0).length >
+                0 ? (
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart
-                      data={driverPerformance.filter(d => d.totalTrips > 0).slice(0, 10)}
+                      data={driverPerformance
+                        .filter((d) => d.totalTrips > 0)
+                        .slice(0, 10)}
                       margin={{ top: 5, right: 30, left: 20, bottom: 25 }}
                       layout="vertical"
                     >
-                      <CartesianGrid strokeDasharray="3 3" horizontal={true} vertical={false} />
-                      <XAxis type="number" tickFormatter={(value) => `₹${value}`} />
-                      <YAxis 
-                        type="category" 
-                        dataKey="name" 
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        horizontal={true}
+                        vertical={false}
+                      />
+                      <XAxis
+                        type="number"
+                        tickFormatter={(value) => `₹${value}`}
+                      />
+                      <YAxis
+                        type="category"
+                        dataKey="name"
                         width={100}
                         tick={{ fontSize: 12 }}
                       />
                       <Tooltip
-                        formatter={(value: number) => [`₹${value.toFixed(2)}`, 'Cost per KM']}
+                        formatter={(value: number) => [
+                          `₹${value.toFixed(2)}`,
+                          "Cost per KM",
+                        ]}
                         labelFormatter={(label) => `Driver: ${label}`}
                       />
-                      <Bar 
-                        dataKey="costPerKm" 
+                      <Bar
+                        dataKey="costPerKm"
                         name="Cost per KM"
                         fill="#8884d8"
                         minPointSize={2}
-                        label={{ position: 'right', formatter: (value: number) => `₹${value.toFixed(2)}` }}
+                        label={{
+                          position: "right",
+                          formatter: (value: number) => `₹${value.toFixed(2)}`,
+                        }}
                       >
                         {driverPerformance
-                          .filter(d => d.totalTrips > 0)
+                          .filter((d) => d.totalTrips > 0)
                           .slice(0, 10)
                           .map((driver, index) => (
-                            <Cell 
-                              key={`cell-${index}`} 
-                              fill={driver.costPerKm < 10 ? '#4CAF50' : driver.costPerKm < 15 ? '#FFC107' : '#EF5350'} 
+                            <Cell
+                              key={`cell-${index}`}
+                              fill={
+                                driver.costPerKm < 10
+                                  ? "#4CAF50"
+                                  : driver.costPerKm < 15
+                                    ? "#FFC107"
+                                    : "#EF5350"
+                              }
                             />
-                          ))
-                        }
+                          ))}
                       </Bar>
                     </BarChart>
                   </ResponsiveContainer>
@@ -661,7 +857,7 @@ const DriverInsightsPage: React.FC = () => {
               </div>
             </div>
           </div>
-          
+
           {/* Driver of the Month */}
           {summaryMetrics.topDriver && (
             <div className="fixed bottom-6 right-6 bg-white p-4 rounded-lg shadow-lg border-l-4 border-primary-500 max-w-xs animate-slide-up z-10">
@@ -670,10 +866,15 @@ const DriverInsightsPage: React.FC = () => {
                   <User className="h-6 w-6 text-primary-600" />
                 </div>
                 <div>
-                  <h3 className="font-medium text-gray-900">Driver of the Month</h3>
-                  <p className="text-lg font-bold text-primary-600">{summaryMetrics.topDriver.name}</p>
+                  <h3 className="font-medium text-gray-900">
+                    Driver of the Month
+                  </h3>
+                  <p className="text-lg font-bold text-primary-600">
+                    {summaryMetrics.topDriver.name}
+                  </p>
                   <p className="text-sm text-gray-600">
-                    ₹{summaryMetrics.topDriver.costPerKm.toFixed(2)}/km • {summaryMetrics.topDriver.totalTrips} trips
+                    ₹{summaryMetrics.topDriver.costPerKm.toFixed(2)}/km •{" "}
+                    {summaryMetrics.topDriver.totalTrips} trips
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- compute avg load per trip and driver utilization metrics
- show these new metrics in Driver Insights summary

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_686cd02eca40832493d759d9eb627044