### PR TITLE
Set default date ranges to all time

### DIFF
--- a/src/components/ai/DriverAIInsights.tsx
+++ b/src/components/ai/DriverAIInsights.tsx
@@ -10,7 +10,6 @@ import {
   getMaintenanceCostInsight,
   DriverInsight
 } from '../../utils/driverAnalytics';
-import { subMonths } from 'date-fns';
 import { TrendingUp, AlertTriangle, IndianRupee, PenTool } from 'lucide-react';
 import CollapsibleSection from '../ui/CollapsibleSection';
 
@@ -34,7 +33,7 @@ const DriverAIInsights: React.FC<DriverAIInsightsProps> = ({
   const range = useMemo(() => {
     if (dateRange) return dateRange;
     const end = new Date();
-    return { start: subMonths(end, 3), end };
+    return { start: new Date('2020-01-01'), end };
   }, [dateRange]);
 
   const insights = useMemo(() => {

--- a/src/components/drivers/DriverInsightsPanel.tsx
+++ b/src/components/drivers/DriverInsightsPanel.tsx
@@ -27,7 +27,7 @@ const DriverInsightsPanel: React.FC<DriverInsightsPanelProps> = ({
   driver,
   trips
 }) => {
-  const [timeFilter, setTimeFilter] = useState<'lastThreeMonths' | 'thisMonth' | 'allTime'>('lastThreeMonths');
+  const [timeFilter, setTimeFilter] = useState<'lastThreeMonths' | 'thisMonth' | 'allTime'>('allTime');
   
   // Define date range based on time filter
   const dateRange = useMemo(() => {

--- a/src/components/maintenance/MaintenanceDashboardFilters.tsx
+++ b/src/components/maintenance/MaintenanceDashboardFilters.tsx
@@ -33,6 +33,7 @@ const MaintenanceDashboardFilters: React.FC<MaintenanceDashboardFiltersProps> = 
               <div className="flex-grow">
                 <Select
                   options={[
+                    { value: 'allTime', label: 'All Time' },
                     { value: 'thisMonth', label: 'This Month' },
                     { value: 'lastMonth', label: 'Last Month' },
                     { value: 'thisYear', label: 'This Year' },
@@ -56,13 +57,14 @@ const MaintenanceDashboardFilters: React.FC<MaintenanceDashboardFiltersProps> = 
               <div className="mt-2 flex items-center">
                 <Calendar className="h-4 w-4 text-gray-500 mr-2" />
                 <span className="text-sm text-gray-600 bg-gray-100 px-3 py-1 rounded-md font-medium">
-                  {dateRangeFilter === 'today' ? 'Today' : 
+                  {dateRangeFilter === 'today' ? 'Today' :
                    dateRangeFilter === 'yesterday' ? 'Yesterday' :
                    dateRangeFilter === 'last7Days' ? 'Last 7 Days' :
                    dateRangeFilter === 'thisMonth' ? 'This Month' :
                    dateRangeFilter === 'lastMonth' ? 'Last Month' :
                    dateRangeFilter === 'thisYear' ? 'This Year' :
-                   dateRangeFilter === 'lastYear' ? 'Last Year' : 'Custom Range'}
+                   dateRangeFilter === 'lastYear' ? 'Last Year' :
+                   dateRangeFilter === 'allTime' ? 'All Time' : 'Custom Range'}
                 </span>
               </div>
             )}

--- a/src/components/trips/TripDashboard.tsx
+++ b/src/components/trips/TripDashboard.tsx
@@ -20,7 +20,7 @@ interface TripDashboardProps {
 type DateFilterType = 'lastMonth' | 'last3Months' | 'last6Months' | 'last12Months' | 'allTime' | 'custom';
 
 const TripDashboard: React.FC<TripDashboardProps> = ({ trips, vehicles, drivers }) => {
-  const [dateFilterType, setDateFilterType] = useState<DateFilterType>('last3Months');
+  const [dateFilterType, setDateFilterType] = useState<DateFilterType>('allTime');
   const [customStartDate, setCustomStartDate] = useState<string>(format(subMonths(new Date(), 3), 'yyyy-MM-dd'));
   const [customEndDate, setCustomEndDate] = useState<string>(format(new Date(), 'yyyy-MM-dd'));
   

--- a/src/components/vehicles/DocumentSummaryPanel.tsx
+++ b/src/components/vehicles/DocumentSummaryPanel.tsx
@@ -206,7 +206,7 @@ const DocumentSummaryPanel: React.FC<DocumentSummaryPanelProps> = ({ isOpen, onC
   // State variables
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [loading, setLoading] = useState(true);
-  const [dateRange, setDateRange] = useState<'thisMonth' | 'lastMonth' | 'thisYear' | 'lastYear' | 'custom'>('thisMonth');
+  const [dateRange, setDateRange] = useState<'allTime' | 'thisMonth' | 'lastMonth' | 'thisYear' | 'lastYear' | 'custom'>('allTime');
   const [customStartDate, setCustomStartDate] = useState<string>('');
   const [customEndDate, setCustomEndDate] = useState<string>('');
   const [vehicleFilter, setVehicleFilter] = useState<string>('all');
@@ -218,11 +218,8 @@ const DocumentSummaryPanel: React.FC<DocumentSummaryPanelProps> = ({ isOpen, onC
   // Initialize date ranges
   useEffect(() => {
     const today = new Date();
-    const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
-    const lastDayOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
-    
-    setCustomStartDate(firstDayOfMonth.toISOString().split('T')[0]);
-    setCustomEndDate(lastDayOfMonth.toISOString().split('T')[0]);
+    setCustomStartDate('2020-01-01');
+    setCustomEndDate(today.toISOString().split('T')[0]);
   }, []);
 
   // Fetch vehicle data when the panel opens
@@ -249,6 +246,11 @@ const DocumentSummaryPanel: React.FC<DocumentSummaryPanelProps> = ({ isOpen, onC
     const now = new Date();
     
     switch (dateRange) {
+      case 'allTime':
+        return {
+          start: new Date('2020-01-01'),
+          end: now
+        };
       case 'thisMonth':
         return {
           start: startOfMonth(now),
@@ -681,6 +683,7 @@ const DocumentSummaryPanel: React.FC<DocumentSummaryPanelProps> = ({ isOpen, onC
                     <Select
                       label="Date Range"
                       options={[
+                        { value: 'allTime', label: 'All Time' },
                         { value: 'thisMonth', label: 'This Month' },
                         { value: 'lastMonth', label: 'Last Month' },
                         { value: 'thisYear', label: 'This Year' },

--- a/src/pages/MaintenancePage.tsx
+++ b/src/pages/MaintenancePage.tsx
@@ -20,7 +20,7 @@ import { useQuery } from '@tanstack/react-query';
 
 const MaintenancePage = () => {
   const navigate = useNavigate();
-  const [dateRangeFilter, setDateRangeFilter] = useState('last30Days');
+  const [dateRangeFilter, setDateRangeFilter] = useState('allTime');
   const [customDateRange, setCustomDateRange] = useState({
     start: '',
     end: ''
@@ -48,11 +48,8 @@ const MaintenancePage = () => {
   // Initialize custom date range values
   useEffect(() => {
     const today = new Date();
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(today.getDate() - 30);
-    
     setCustomDateRange({
-      start: thirtyDaysAgo.toISOString().split('T')[0],
+      start: '2020-01-01',
       end: today.toISOString().split('T')[0]
     });
   }, []);

--- a/src/pages/TripPnlReportsPage.tsx
+++ b/src/pages/TripPnlReportsPage.tsx
@@ -59,7 +59,7 @@ const TripPnlReportsPage: React.FC = () => {
   const [selectedDriver, setSelectedDriver] = useState('');
   const [selectedWarehouse, setSelectedWarehouse] = useState('');
   const [selectedProfitStatus, setSelectedProfitStatus] = useState('');
-  const [selectedDatePreset, setSelectedDatePreset] = useState('last30');
+  const [selectedDatePreset, setSelectedDatePreset] = useState('alltime');
   const [customStartDate, setCustomStartDate] = useState('');
   const [customEndDate, setCustomEndDate] = useState('');
   const [showFilters, setShowFilters] = useState(false);
@@ -119,6 +119,13 @@ const TripPnlReportsPage: React.FC = () => {
       getValue: () => ({
         startDate: startOfYear(subYears(new Date(), 1)),
         endDate: endOfYear(subYears(new Date(), 1))
+      })
+    },
+    {
+      label: 'All Time',
+      getValue: () => ({
+        startDate: new Date('2020-01-01'),
+        endDate: new Date()
       })
     }
   ];
@@ -278,7 +285,7 @@ const TripPnlReportsPage: React.FC = () => {
     setSelectedDriver('');
     setSelectedWarehouse('');
     setSelectedProfitStatus('');
-    setSelectedDatePreset('last30');
+    setSelectedDatePreset('alltime');
     setCustomStartDate('');
     setCustomEndDate('');
   };

--- a/src/pages/drivers/DriverInsightsPage.tsx
+++ b/src/pages/drivers/DriverInsightsPage.tsx
@@ -76,7 +76,7 @@ const DriverInsightsPage: React.FC = () => {
   // Filters
   const [dateRange, setDateRange] = useState<
     "thisMonth" | "lastThreeMonths" | "lastSixMonths" | "lastYear" | "allTime"
-  >("lastThreeMonths");
+  >("allTime");
   const [selectedDriver, setSelectedDriver] = useState<string>("all");
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [showFilters, setShowFilters] = useState(true);
@@ -579,7 +579,7 @@ const DriverInsightsPage: React.FC = () => {
                 variant="outline"
                 size="sm"
                 onClick={() => {
-                  setDateRange("lastThreeMonths");
+                  setDateRange("allTime");
                   setSelectedDriver("all");
                   setSearchTerm("");
                 }}

--- a/src/utils/maintenanceAnalytics.ts
+++ b/src/utils/maintenanceAnalytics.ts
@@ -69,6 +69,11 @@ export const getDateRangeForFilter = (filterType: string, customStart?: string, 
         end: endOfYear(lastYear)
       };
     }
+    case 'allTime':
+      return {
+        start: new Date('2020-01-01'),
+        end: now
+      };
     case 'custom':
       if (customStart && customEnd) {
         return {


### PR DESCRIPTION
## Summary
- default date range filters to 'All Time' across dashboards and reports
- add 'All Time' option to maintenance and document filters
- widen initial ranges to start from 2020

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cfba483348324a8f4b5cd88ae5e79