### PR TITLE
Add CurrencyInput for service cost

### DIFF
--- a/src/components/maintenance/ServiceGroupItem.tsx
+++ b/src/components/maintenance/ServiceGroupItem.tsx
@@ -7,12 +7,13 @@ import {
   MaintenanceTask,
 } from "../../types/maintenance";
 import Input from "../ui/Input";
+import CurrencyInput from "../ui/CurrencyInput";
 import FileUpload from "../ui/FileUpload";
 import Switch from "../ui/Switch";
 import VendorSelector from "./VendorSelector";
 import MaintenanceSelector from "./MaintenanceSelector";
 import SearchableSelect from "../ui/SearchableSelect";
-import { Trash2, IndianRupee, Battery, Disc, Paperclip } from "lucide-react";
+import { Trash2, Battery, Disc, Paperclip } from "lucide-react";
 import { addYears, format } from "date-fns";
 
 interface ServiceGroupItemProps {
@@ -77,11 +78,9 @@ const ServiceGroupItem: React.FC<ServiceGroupItemProps> = ({
             )}
           />
 
-          <Input
-            label="Cost (₹)"
-            type="number"
+          <CurrencyInput
+            label="Cost"
             className="ps-8"
-            icon={<IndianRupee className="h-4 w-4" />}
             error={errors.service_groups?.[index]?.cost?.message}
             required
             {...register(`service_groups.${index}.cost` as const, {

--- a/src/components/ui/CurrencyInput.tsx
+++ b/src/components/ui/CurrencyInput.tsx
@@ -1,0 +1,19 @@
+import React, { forwardRef } from 'react';
+import { IndianRupee } from 'lucide-react';
+import Input from './Input';
+
+interface CurrencyInputProps
+  extends Omit<React.ComponentProps<typeof Input>, 'icon' | 'type'> {}
+
+const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
+  ({ ...props }, ref) => (
+    <Input
+      ref={ref}
+      type="number"
+      icon={<IndianRupee className="h-4 w-4" />}
+      {...props}
+    />
+  )
+);
+
+export default CurrencyInput;


### PR DESCRIPTION
## Summary
- create `CurrencyInput` wrapper with rupee icon
- use `CurrencyInput` for service group cost field
- update imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d4ae6df608324a06b1cee51e06d76