### PR TITLE
Use CurrencyInput for trip cost fields

### DIFF
--- a/src/components/trips/TripForm.tsx
+++ b/src/components/trips/TripForm.tsx
@@ -8,6 +8,7 @@ import { analyzeTripAndGenerateAlerts } from '../../utils/aiAnalytics';
 import { Calendar, Fuel, MapPin, FileText, Truck, IndianRupee, Weight, AlertTriangle, Package, ArrowLeftRight, Repeat, Info, Loader } from 'lucide-react';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
+import CurrencyInput from '../ui/CurrencyInput';
 import Select from '../ui/Select';
 import Checkbox from '../ui/Checkbox';
 import FileUpload from '../ui/FileUpload';
@@ -702,11 +703,8 @@ const TripForm: React.FC<TripFormProps> = ({
                 })}
               />
 
-              <Input
-                label="Fuel Cost (₹/L)"
-                type="number"
-                inputMode="decimal"
-                icon={<IndianRupee className="h-4 w-4" />}
+              <CurrencyInput
+                label="Fuel Cost (/L)"
                 step="0.01"
                 error={errors.fuel_cost?.message}
                 {...register('fuel_cost', {
@@ -740,78 +738,42 @@ const TripForm: React.FC<TripFormProps> = ({
       >
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
           <div className="form-group">
-            <label
-              htmlFor="unloading_expense"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-            >
-              Unloading Expense
-            </label>
-            <div className="flex items-center">
-              <span className="mr-2 text-gray-500">₹</span>
-              <input
-                id="unloading_expense"
-                type="number"
-                inputMode="decimal"
-                placeholder="0"
-                className="block w-full rounded-lg border-gray-300 dark:border-gray-600 shadow-sm focus:border-primary-400 dark:focus:border-primary-500 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 focus:ring-opacity-50 transition-colors duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2"
-                {...register('unloading_expense', {
-                  valueAsNumber: true,
-                  min: { value: 0, message: 'Expense must be positive' }
-                })}
-              />
-            </div>
+            <CurrencyInput
+              label="Unloading Expense"
+              {...register('unloading_expense', {
+                valueAsNumber: true,
+                min: { value: 0, message: 'Expense must be positive' }
+              })}
+              error={errors.unloading_expense?.message}
+            />
             {errors.unloading_expense && (
               <p className="form-error">{errors.unloading_expense.message}</p>
             )}
           </div>
 
           <div className="form-group">
-            <label
-              htmlFor="driver_expense"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-            >
-              Driver/Misc Expense
-            </label>
-            <div className="flex items-center">
-              <span className="mr-2 text-gray-500">₹</span>
-              <input
-                id="driver_expense"
-                type="number"
-                inputMode="decimal"
-                placeholder="0"
-                className="block w-full rounded-lg border-gray-300 dark:border-gray-600 shadow-sm focus:border-primary-400 dark:focus:border-primary-500 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 focus:ring-opacity-50 transition-colors duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2"
-                {...register('driver_expense', {
-                  valueAsNumber: true,
-                  min: { value: 0, message: 'Expense must be positive' }
-                })}
-              />
-            </div>
+            <CurrencyInput
+              label="Driver/Misc Expense"
+              {...register('driver_expense', {
+                valueAsNumber: true,
+                min: { value: 0, message: 'Expense must be positive' }
+              })}
+              error={errors.driver_expense?.message}
+            />
             {errors.driver_expense && (
               <p className="form-error">{errors.driver_expense.message}</p>
             )}
           </div>
 
           <div className="form-group">
-            <label
-              htmlFor="road_rto_expense"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-            >
-              Road/RTO Expense
-            </label>
-            <div className="flex items-center">
-              <span className="mr-2 text-gray-500">₹</span>
-              <input
-                id="road_rto_expense"
-                type="number"
-                inputMode="decimal"
-                placeholder="0"
-                className="block w-full rounded-lg border-gray-300 dark:border-gray-600 shadow-sm focus:border-primary-400 dark:focus:border-primary-500 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 focus:ring-opacity-50 transition-colors duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-2"
-                {...register('road_rto_expense', {
-                  valueAsNumber: true,
-                  min: { value: 0, message: 'Expense must be positive' }
-                })}
-              />
-            </div>
+            <CurrencyInput
+              label="Road/RTO Expense"
+              {...register('road_rto_expense', {
+                valueAsNumber: true,
+                min: { value: 0, message: 'Expense must be positive' }
+              })}
+              error={errors.road_rto_expense?.message}
+            />
             {errors.road_rto_expense && (
               <p className="form-error">{errors.road_rto_expense.message}</p>
             )}

--- a/src/components/ui/CurrencyInput.tsx
+++ b/src/components/ui/CurrencyInput.tsx
@@ -1,0 +1,91 @@
+import React, { forwardRef, useId } from 'react';
+import { cn } from '../../utils/cn';
+
+interface CurrencyInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  helperText?: string;
+  error?: string;
+  fullWidth?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
+  (
+    {
+      label,
+      helperText,
+      error,
+      fullWidth = true,
+      className,
+      size = 'md',
+      required,
+      id,
+      type = 'number',
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const inputId = id || `currency-input-${generatedId}`;
+
+    const sizeClasses: Record<string, string> = {
+      sm: 'px-2 py-1 text-sm',
+      md: 'px-3 py-2',
+      lg: 'px-4 py-3 text-lg'
+    };
+
+    const prefixPadding: Record<string, string> = {
+      sm: 'pl-7',
+      md: 'pl-9',
+      lg: 'pl-10'
+    };
+
+    return (
+      <div className={cn('form-group', fullWidth && 'w-full')}>
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+          >
+            {label}
+            {required && (
+              <span className="text-error-500 dark:text-error-400 ml-1">*</span>
+            )}
+          </label>
+        )}
+        <div className={cn('relative', fullWidth && 'w-full')}>
+          <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400 dark:text-gray-500">
+            ₹
+          </div>
+          <input
+            id={inputId}
+            ref={ref}
+            type={type}
+            inputMode="decimal"
+            className={cn(
+              'block w-full rounded-lg border-gray-300 dark:border-gray-600 shadow-sm focus:border-primary-400 dark:focus:border-primary-500 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 focus:ring-opacity-50 transition-colors duration-200 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100',
+              error &&
+                'border-error-500 dark:border-error-500 focus:ring-error-200 dark:focus:ring-error-800 focus:border-error-500 dark:focus:border-error-500',
+              prefixPadding[size],
+              sizeClasses[size],
+              className
+            )}
+            {...props}
+          />
+        </div>
+        {(helperText || error) && (
+          <p
+            className={cn(
+              'mt-1 text-sm',
+              error ? 'text-error-500 dark:text-error-400' : 'text-gray-500 dark:text-gray-400'
+            )}
+          >
+            {error || helperText}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+export default CurrencyInput;


### PR DESCRIPTION
## Summary
- add `CurrencyInput` component for Rupee currency fields
- swap trip cost inputs to use the new `CurrencyInput`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d4aeef630832488344149b3813af1