### PR TITLE
Use CurrencyInput in MaintenanceTasksAdmin

### DIFF
--- a/src/components/ui/CurrencyInput.tsx
+++ b/src/components/ui/CurrencyInput.tsx
@@ -1,0 +1,32 @@
+import React, { forwardRef } from 'react';
+import Input from './Input';
+
+interface CurrencyInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  label?: string;
+  helperText?: string;
+  error?: string;
+  fullWidth?: boolean;
+  iconPosition?: 'left' | 'right';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
+  (
+    {
+      iconPosition = 'left',
+      ...props
+    },
+    ref
+  ) => (
+    <Input
+      {...props}
+      ref={ref}
+      type="number"
+      step="0.01"
+      icon={<span>₹</span>}
+      iconPosition={iconPosition}
+    />
+  )
+);
+
+export default CurrencyInput;

--- a/src/pages/admin/MaintenanceTasksAdmin.tsx
+++ b/src/pages/admin/MaintenanceTasksAdmin.tsx
@@ -4,6 +4,7 @@ import { MaintenanceItem, MAINTENANCE_ITEMS, MAINTENANCE_GROUPS } from '../../ty
 import { PlusCircle, Edit2, Trash2, AlertTriangle, ChevronLeft } from 'lucide-react';
 import Button from '../../components/ui/Button';
 import Input from '../../components/ui/Input';
+import CurrencyInput from '../../components/ui/CurrencyInput';
 import Select from '../../components/ui/Select';
 import { useNavigate } from 'react-router-dom';
 
@@ -125,12 +126,11 @@ const MaintenanceTasksAdmin: React.FC = () => {
               }}
             />
 
-            <Input
-              label="Average Cost (₹)"
-              type="number"
+            <CurrencyInput
+              label="Average Cost"
               value={editingItem?.averageCost || newItem.averageCost || ''}
               onChange={e => {
-                const value = parseInt(e.target.value);
+                const value = parseFloat(e.target.value);
                 if (editingItem) {
                   setEditingItem({ ...editingItem, averageCost: value });
                 } else {


### PR DESCRIPTION
## Summary
- create `CurrencyInput` component for rupee-prefixed numbers
- switch the Average Cost field to use `CurrencyInput`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d4af0b91c8324b84f0a641639d9f2