### PR TITLE
refactor: simplify header navigation

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,44 +1,21 @@
-import { useEffect, useState } from "react";
-import { getRole, Role } from "../../utils/session";
 import ThemeToggle from "../ui/ThemeToggle"; // correct path from layout/ → ui/
 
-const Header: React.FC = () => {
-  const [role, setRole] = useState<Role | null>(null);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const r = await getRole();
-        setRole(r);
-      } catch {
-        // ignore if not logged in yet
-      }
-    })();
-  }, []);
-
-  const isOwner = role === "OWNER";
-
+const Header = () => {
   return (
     <header className="border-b p-3 flex items-center gap-3">
       <div className="font-semibold">AVS</div>
       <nav className="ml-auto flex gap-3 text-sm">
-        {isOwner ? (
-          <>
-            <a href="/">Dashboard</a>
-            <a href="/vehicles">Vehicles</a>
-            <a href="/trips">Trips</a>
-            <a href="/maintenance">Maintenance</a>
-            <a href="/drivers">Drivers</a>
-            <a href="/alerts">AI Alerts</a>
-            <a href="/admin">Admin</a>
-            <a href="/trip-pnl-reports">Trip P&amp;L</a>
-            <a href="/parts-health">Parts Health</a>
-            <a href="/notifications">Notifications</a>
-            <a href="/drivers/insights">Driver Insights</a>
-          </>
-        ) : (
-          <a href="/add">Add</a>
-        )}
+        <a href="/">Dashboard</a>
+        <a href="/vehicles">Vehicles</a>
+        <a href="/trips">Trips</a>
+        <a href="/maintenance">Maintenance</a>
+        <a href="/drivers">Drivers</a>
+        <a href="/alerts">AI Alerts</a>
+        <a href="/admin">Admin</a>
+        <a href="/trip-pnl-reports">Trip P&amp;L</a>
+        <a href="/parts-health">Parts Health</a>
+        <a href="/notifications">Notifications</a>
+        <a href="/drivers/insights">Driver Insights</a>
       </nav>
       <ThemeToggle />
     </header>


### PR DESCRIPTION
## Summary
- remove role-based logic from header
- show full owner navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d63fa99b883248e8b28dfd0cb4614