### PR TITLE
Remove role-based logic from header navigation

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,47 +13,13 @@ import {
 } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { supabase } from "../../utils/supabaseClient";
-import { getRole, Role } from "../../utils/session";
-import { getRole, Role } from "../../utils/session";
 import ThemeToggle from "../ui/ThemeToggle";
 
 const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [userRole, setUserRole] = useState<Role | null>(null);
-  const [userRole, setUserRole] = useState<Role | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
-
-  // Fetch user role on component mount
-  useEffect(() => {
-    const fetchUserRole = async () => {
-      try {
-        const role = await getRole();
-        setUserRole(role);
-      } catch (error) {
-        console.error('Error fetching user role:', error);
-        setUserRole(null);
-      }
-    };
-    
-    fetchUserRole();
-  }, []);
-
-  // Fetch user role on component mount
-  useEffect(() => {
-    const fetchUserRole = async () => {
-      try {
-        const role = await getRole();
-        setUserRole(role);
-      } catch (error) {
-        console.error('Error fetching user role:', error);
-        setUserRole(null);
-      }
-    };
-    
-    fetchUserRole();
-  }, []);
 
   const handleLogout = async () => {
     await supabase.auth.signOut();


### PR DESCRIPTION
## Summary
- Simplify Header component by removing role-based imports and state
- Render navigation links unconditionally without role checks

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d7aeef84c832493a57b63044241d3