### PR TITLE
chore: move papaparse types to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@supabase/supabase-js": "^2.39.3",
         "@tanstack/react-query": "^5.80.10",
         "@tanstack/react-query-devtools": "^5.80.10",
-        "@types/papaparse": "^5.3.14",
         "clsx": "^2.1.1",
         "date-fns": "^2.30.0",
         "file-saver": "^2.0.5",
@@ -36,6 +35,7 @@
       "devDependencies": {
         "@eslint/js": "^9.9.1",
         "@types/file-saver": "^2.0.7",
+        "@types/papaparse": "^5.3.14",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -1512,6 +1512,7 @@
       "version": "5.3.16",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.16.tgz",
       "integrity": "sha512-T3VuKMC2H0lgsjI9buTB3uuKj3EMD2eap1MOuEQuBQ44EnDx/IkGhU6EwiTf9zG3za4SKlmwKAImdDKdNnCsXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@supabase/supabase-js": "^2.39.3",
     "@tanstack/react-query": "^5.80.10",
     "@tanstack/react-query-devtools": "^5.80.10",
-    "@types/papaparse": "^5.3.14",
     "clsx": "^2.1.1",
     "date-fns": "^2.30.0",
     "file-saver": "^2.0.5",
@@ -39,6 +38,7 @@
   "devDependencies": {
     "@eslint/js": "^9.9.1",
     "@types/file-saver": "^2.0.7",
+    "@types/papaparse": "^5.3.14",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
## Summary
- move `@types/papaparse` from runtime dependencies to devDependencies
- update lockfile

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4009fe03c8324acd7e9e414221b4f