### PR TITLE
refactor: cache trips in TripForm

### DIFF
--- a/src/pages/TripDetailsPage.tsx
+++ b/src/pages/TripDetailsPage.tsx
@@ -4,7 +4,7 @@ import Layout from '../components/layout/Layout';
 import TripDetails from '../components/trips/TripDetails';
 import TripForm from '../components/trips/TripForm';
 import { Trip, TripFormData, Vehicle, Driver, Destination, Warehouse } from '../types';
-import { getTrip, getVehicle, getDriver, getDestination, updateTrip, deleteTrip, getWarehouse } from '../utils/storage';
+import { getTrip, getVehicle, getDriver, getDestination, updateTrip, deleteTrip, getWarehouse, getTrips } from '../utils/storage';
 import { getMaterialTypes, MaterialType } from '../utils/materialTypes';
 import { getAIAlerts, AIAlert } from '../utils/aiAnalytics';
 import TripMap from '../components/maps/TripMap';
@@ -26,6 +26,7 @@ const TripDetailsPage: React.FC = () => {
   const [materialTypes, setMaterialTypes] = useState<MaterialType[]>([]);
   const [aiAlerts, setAiAlerts] = useState<AIAlert[]>([]);
   const [showMapModal, setShowMapModal] = useState(false);
+  const [trips, setTrips] = useState<Trip[]>([]);
   
   // Load trip data
   useEffect(() => {
@@ -37,12 +38,13 @@ const TripDetailsPage: React.FC = () => {
           if (tripData) {
             setTrip(tripData);
             
-            // Load related vehicle, driver, material types, and AI alerts
-            const [vehicleData, driverData, materialTypesData, aiAlertsData] = await Promise.all([
+            // Load related vehicle, driver, material types, AI alerts, and all trips
+            const [vehicleData, driverData, materialTypesData, aiAlertsData, tripsData] = await Promise.all([
               getVehicle(tripData.vehicle_id),
               getDriver(tripData.driver_id),
               getMaterialTypes(),
-              getAIAlerts()
+              getAIAlerts(),
+              getTrips()
             ]);
             
             setVehicle(vehicleData || undefined);
@@ -57,6 +59,7 @@ const TripDetailsPage: React.FC = () => {
                 )
               : [];
             setAiAlerts(tripAlerts);
+            setTrips(Array.isArray(tripsData) ? tripsData : []);
             
             // Load warehouse and destinations for map
             if (tripData.warehouse_id) {
@@ -235,6 +238,7 @@ const TripDetailsPage: React.FC = () => {
             }}
             onSubmit={handleUpdate}
             isSubmitting={isSubmitting}
+            trips={trips}
           />
         </div>
       ) : (

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -172,9 +172,10 @@ const TripsPage: React.FC = () => {
             </Button>
           </div>
           
-          <TripForm 
-            onSubmit={handleAddTrip} 
+          <TripForm
+            onSubmit={handleAddTrip}
             isSubmitting={isSubmitting}
+            trips={trips}
           />
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- add trips prop with caching to TripForm
- use cached trips in effects instead of calling getTrips
- pass trips from TripsPage and TripDetailsPage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a40105f3a88324a4a19b7cf0221fa2