### PR TITLE
refactor: use license_number for drivers

### DIFF
--- a/src/components/drivers/DriverForm.tsx
+++ b/src/components/drivers/DriverForm.tsx
@@ -177,7 +177,7 @@ const DriverForm: React.FC<DriverFormProps> = ({
         address: driver?.permanent_address || driver?.temporary_address || "",
         contact_number: driver?.contact_number || "",
         email: driver?.email || "",
-        dl_number: driver?.license_number || licenseNumber,
+        license_number: driver?.license_number || licenseNumber,
         vehicle_class:
           (driver?.vehicle_class &&
             driver?.vehicle_class.map((v: any) => v?.cov)) ||

--- a/src/components/drivers/DriverSummaryModal.tsx
+++ b/src/components/drivers/DriverSummaryModal.tsx
@@ -79,7 +79,7 @@ const DriverSummaryModal: React.FC<DriverSummaryModalProps> = ({
             <Truck className="h-6 w-6 text-primary-600 mr-3" />
             <div>
               <h2 className="text-xl font-semibold text-gray-900">{driver.name}</h2>
-              <p className="text-sm text-gray-500">License: {driver.license_number || driver.dl_number}</p>
+              <p className="text-sm text-gray-500">License: {driver.license_number}</p>
             </div>
           </div>
           <button

--- a/src/components/drivers/DriverWhatsAppShareModal.tsx
+++ b/src/components/drivers/DriverWhatsAppShareModal.tsx
@@ -32,7 +32,7 @@ const DriverWhatsAppShareModal: React.FC<DriverWhatsAppShareModalProps> = ({
     return encodeURIComponent(
       `👨‍✈️ *Driver Profile (Auto Vital Solution)*\n\n` +
       `📌 *Name:* ${driver.name}\n` +
-      `🪪 *License:* ${driver.dl_number || driver.license_number || 'N/A'}\n` +
+      `🪪 *License:* ${driver.license_number || 'N/A'}\n` +
       `📞 *Contact:* ${driver.contact_number || 'N/A'}\n` +
       `📧 *Email:* ${driver.email || 'N/A'}\n` +
       `⏱️ *Experience:* ${driver.experience_years} years\n` +

--- a/src/pages/DriversPage.tsx
+++ b/src/pages/DriversPage.tsx
@@ -643,7 +643,7 @@ const DriversPage: React.FC = () => {
                           handleOpenShareModal(driver, e);
                         }}
                         className="ml-2 text-green-600 hover:text-green-800"
-                        message={`Driver details for ${driver.name} (License: ${driver.license_number || driver.dl_number}) from Auto Vital Solution.`}
+                        message={`Driver details for ${driver.name} (License: ${driver.license_number}) from Auto Vital Solution.`}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- replace legacy dl_number field with license_number across driver components
- update driver summary and sharing messages to show license_number
- ensure driver form sets license_number from fetched data

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected lexical declaration in case block and Unnecessary escape character in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a885accd588324aaa684108e116e49