### PR TITLE
Upload vehicle document files before saving vehicles

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,12 +59,12 @@ export interface Vehicle {
   puc_document_file?: File[];
 
   // Document paths for storage
-  rc_document_url?: string[];
-  insurance_document_url?: string[];
-  fitness_document_url?: string[];
-  tax_document_url?: string[];
-  permit_document_url?: string[];
-  puc_document_url?: string[];
+  rc_document_url?: string;
+  insurance_document_url?: string;
+  fitness_document_url?: string;
+  tax_document_url?: string;
+  permit_document_url?: string;
+  puc_document_url?: string;
 
   // Legacy boolean flags (for backward compatibility)
   rc_copy?: boolean;


### PR DESCRIPTION
## Summary
- upload vehicle document files to Supabase storage and map URLs before vehicle creation
- switch vehicle document URL fields to strings for consistency

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected lexical declaration in case block, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a88b7933a88324b7cd0ec4b60aa7b0