### PR TITLE
feat: add fuel bill and station fields for trips

### DIFF
--- a/src/components/trips/TripForm.tsx
+++ b/src/components/trips/TripForm.tsx
@@ -763,6 +763,20 @@ const TripForm: React.FC<TripFormProps> = ({
                   }
                 })}
               />
+
+              <Input
+                label="Fuel Station"
+                placeholder="Enter station name"
+                error={errors.station?.message}
+                {...register('station')}
+              />
+
+              <Input
+                label="Fuel Station ID"
+                placeholder="Enter station ID"
+                error={errors.fuel_station_id?.message}
+                {...register('fuel_station_id')}
+              />
             </div>
 
             {fuelQuantity && fuelCost && (

--- a/src/pages/TripsPage.tsx
+++ b/src/pages/TripsPage.tsx
@@ -77,11 +77,13 @@ const TripsPage: React.FC = () => {
       }
       
       // Create trip without the file object (replaced with URL)
-      const { fuel_bill_file, ...tripData } = data;
-      
+      const { fuel_bill_file, station, fuel_station_id, ...tripData } = data;
+
       // Add trip to storage
       const newTrip = await createTrip({
         ...tripData,
+        station: station?.trim() || undefined,
+        fuel_station_id,
         fuel_bill_url: fuelBillUrl
       });
       

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -286,6 +286,7 @@ export interface Trip {
   end_km: number;
   gross_weight: number;
   station?: string;
+  fuel_station_id?: string;
   refueling_done: boolean;
   fuel_quantity?: number;
   fuel_cost?: number;

--- a/supabase/migrations/20250822120000_station_bill_columns.sql
+++ b/supabase/migrations/20250822120000_station_bill_columns.sql
@@ -1,0 +1,32 @@
+/*
+  # Add fuel bill and station fields to trips
+
+  1. New Columns
+    - `fuel_bill_url` (text) - URL of uploaded fuel bill or trip slip
+    - `station` (text, nullable) - name of fuel station
+    - `fuel_station_id` (uuid, nullable) - reference to fuel station
+*/
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'trips' AND column_name = 'fuel_bill_url'
+  ) THEN
+    ALTER TABLE public.trips ADD COLUMN fuel_bill_url text;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'trips' AND column_name = 'station'
+  ) THEN
+    ALTER TABLE public.trips ADD COLUMN station text;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'trips' AND column_name = 'fuel_station_id'
+  ) THEN
+    ALTER TABLE public.trips ADD COLUMN fuel_station_id uuid;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add migration to support fuel bill URL, station name, and fuel station ID
- capture station info and upload fuel bill files from trip form
- send station details and fuel bill URL on trip submission

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected lexical declaration in case block; Unnecessary escape character)*

------
https://chatgpt.com/codex/tasks/task_e_68a88b7d4d98832491a6901b94a1be75