### PR TITLE
chore: remove fuel station storage functions

### DIFF
--- a/src/components/trips/TripForm.tsx
+++ b/src/components/trips/TripForm.tsx
@@ -3,7 +3,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { format, differenceInDays } from 'date-fns';
 import { nanoid } from 'nanoid';
 import { Trip, TripFormData, Vehicle, Driver, Warehouse, Destination, RouteAnalysis, Alert } from '../../types';
-import { getVehicles, getDrivers, getWarehouses, getDestinations, getDestination, analyzeRoute, createDestination, getVehicle, getFuelStations } from '../../utils/storage';
+import { getVehicles, getDrivers, getWarehouses, getDestinations, getDestination, analyzeRoute, createDestination, getVehicle } from '../../utils/storage';
 import type { FuelStation } from '../../types';
 import { analyzeTripAndGenerateAlerts } from '../../utils/aiAnalytics';
 import { Calendar, Fuel, MapPin, FileText, Truck, IndianRupee, Weight, AlertTriangle, Package, ArrowLeftRight, Repeat, Info, Loader, Settings } from 'lucide-react';
@@ -42,7 +42,7 @@ const TripForm: React.FC<TripFormProps> = ({
   const [warehouses, setWarehouses] = useState<Warehouse[]>([]);
   const [frequentWarehouses, setFrequentWarehouses] = useState<Warehouse[]>([]);
   const [allDestinations, setAllDestinations] = useState<Destination[]>([]);
-  const [fuelStations, setFuelStations] = useState<FuelStation[]>([]);
+  const [fuelStations] = useState<FuelStation[]>([]);
   const [lastTripMileage, setLastTripMileage] = useState<number | undefined>();
   const [tripIdPreview, setTripIdPreview] = useState<string>('');
   const [routeAnalysis, setRouteAnalysis] = useState<RouteAnalysis | undefined>();
@@ -138,13 +138,12 @@ const TripForm: React.FC<TripFormProps> = ({
     const fetchData = async () => {
       setLoading(true);
       try {
-        const [vehiclesData, driversData, warehousesData, destinationsData, materialTypesData, fuelStationsData] = await Promise.all([
+        const [vehiclesData, driversData, warehousesData, destinationsData, materialTypesData] = await Promise.all([
           getVehicles(),
           getDrivers(),
           getWarehouses(),
           getDestinations(),
-          getMaterialTypes(),
-          getFuelStations()
+          getMaterialTypes()
         ]);
         // Filter out archived vehicles
         const activeVehicles = Array.isArray(vehiclesData) ? vehiclesData.filter(v => v.status !== 'archived') : [];
@@ -153,7 +152,6 @@ const TripForm: React.FC<TripFormProps> = ({
         setWarehouses(Array.isArray(warehousesData) ? warehousesData : []);
         setAllDestinations(Array.isArray(destinationsData) ? destinationsData : []);
         setMaterialTypes(Array.isArray(materialTypesData) ? materialTypesData : []);
-        setFuelStations(Array.isArray(fuelStationsData) ? fuelStationsData : []);
       } catch (error) {
         console.error('Error fetching form data:', error);
         toast.error('Failed to load form data');

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -16,7 +16,6 @@ import { loadGoogleMaps } from './googleMapsLoader';
 import { toast } from 'react-toastify';
 import { generateCSV, downloadCSV } from './csvParser';
 import { handleSupabaseError } from './errors';
-import type { FuelStation } from '../types';
 
 // Helper function to check if a value is LTT (Lifetime Tax)
 const isLTT = (value: string | null | undefined): boolean => {
@@ -833,109 +832,6 @@ export const hardDeleteDestination = async (id: string): Promise<boolean> => {
     return false;
   }
 
-  return true;
-};
-
-// Fuel Stations CRUD operations
-export const getFuelStations = async (): Promise<FuelStation[]> => {
-  try {
-    const { data: { user }, error: userError } = await supabase.auth.getUser();
-    
-    if (userError) {
-      if (isNetworkError(userError)) {
-        console.warn('Network error fetching user for fuel stations, returning empty array');
-        return [];
-      }
-      handleSupabaseError('get user for fuel stations', userError);
-      return [];
-    }
-    
-    if (!user) {
-      console.error('No user authenticated');
-      return [];
-    }
-
-    const { data, error } = await supabase
-      .from('fuel_stations')
-      .select('*')
-      .eq('created_by', user.id)
-      .order('created_at', { ascending: false });
-
-    if (error) {
-      handleSupabaseError('fetch fuel stations', error);
-      return [];
-    }
-
-    return data || [];
-  } catch (error) {
-    if (isNetworkError(error)) {
-      console.warn('Network error fetching fuel stations, returning empty array');
-      return [];
-    }
-    handleSupabaseError('get fuel stations', error);
-    return [];
-  }
-  return [];
-};
-
-export const createFuelStation = async (stationData: Omit<FuelStation, 'id' | 'created_at' | 'updated_at' | 'created_by'>): Promise<FuelStation | null> => {
-  try {
-    const userId = await getCurrentUserId();
-    if (!userId) {
-      throw new Error('User not authenticated');
-    }
-
-    const payload = withOwner(stationData, userId);
-
-    const { data, error } = await supabase
-      .from('fuel_stations')
-      .insert(payload)
-      .select('*')
-      .single();
-
-    if (error) {
-      handleSupabaseError('create fuel station', error);
-      throw error;
-    }
-
-    return data;
-  } catch (error) {
-    handleSupabaseError('create fuel station', error);
-    throw error;
-  }
-};
-
-export const updateFuelStation = async (id: string, updates: Partial<FuelStation>): Promise<FuelStation | null> => {
-  try {
-    const { data, error } = await supabase
-      .from('fuel_stations')
-      .update(updates)
-      .eq('id', id)
-      .select('*')
-      .single();
-
-    if (error) {
-      handleSupabaseError('update fuel station', error);
-      throw error;
-    }
-
-    return data;
-  } catch (error) {
-    handleSupabaseError('update fuel station', error);
-    throw error;
-  }
-};
-
-export const deleteFuelStation = async (id: string): Promise<boolean> => {
-  const { error } = await supabase
-    .from('fuel_stations')
-    .delete()
-    .eq('id', id);
-
-  if (error) {
-    handleSupabaseError('delete fuel station', error);
-    return false;
-  }
   return true;
 };
 


### PR DESCRIPTION
## Summary
- remove fuel station CRUD helpers from storage utils
- stop fetching fuel station data in TripForm

## Testing
- `npm test`
- `npm run lint` *(fails: parsing error and lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ab582774cc8324b2cac6fc4652ee81