### PR TITLE
refactor: extract chart wrapper

### DIFF
--- a/src/components/trips/charts/ChartWrapper.tsx
+++ b/src/components/trips/charts/ChartWrapper.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ResponsiveContainer } from 'recharts';
+
+interface ChartWrapperProps {
+  dataLength: number;
+  scrollDirection?: 'x' | 'y';
+  minSizeClass?: string;
+  emptyMessage?: string;
+  children: React.ReactNode;
+}
+
+const ChartWrapper: React.FC<ChartWrapperProps> = ({
+  dataLength,
+  scrollDirection = 'x',
+  minSizeClass,
+  emptyMessage = 'No fuel consumption data available for the selected period',
+  children,
+}) => {
+  const overflowClass = scrollDirection === 'x' ? 'overflow-x-auto' : 'overflow-y-auto';
+  const sizeClass = minSizeClass ?? (scrollDirection === 'x' ? 'min-w-[600px]' : 'min-h-[350px]');
+
+  return (
+    <div className="space-y-2">
+      <div className={`h-72 ${overflowClass}`}>
+        <div className={`${sizeClass} h-full`}>
+          <ResponsiveContainer width="100%" height="100%">
+            {children}
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {dataLength === 0 && (
+        <div className="text-center py-6 text-gray-500 bg-gray-50 rounded-lg">
+          {emptyMessage}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChartWrapper;
+

--- a/src/components/trips/charts/FuelConsumedByVehicleChart.tsx
+++ b/src/components/trips/charts/FuelConsumedByVehicleChart.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell } from 'recharts';
 import { Trip, Vehicle } from '../../../types';
 import { parseISO, isValid, isWithinInterval, format, isBefore } from 'date-fns';
+import ChartWrapper from './ChartWrapper';
 
 interface FuelConsumedByVehicleChartProps {
   trips: Trip[];
@@ -103,68 +104,56 @@ const FuelConsumedByVehicleChart: React.FC<FuelConsumedByVehicleChartProps> = ({
   };
 
   return (
-    <div className="space-y-2">      
-      <div className="h-72 overflow-y-auto">
-        <div className="min-h-[350px] h-full">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              layout="vertical"
-              margin={{ top: 10, right: 30, left: 70, bottom: 10 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" horizontal={true} vertical={false} />
-              <XAxis 
-                type="number" 
-                axisLine={false}
-                tickLine={false}
-                domain={[0, 'auto']} 
-                tick={{ fontSize: 10 }}
-                label={{
-                  value: 'Liters',
-                  position: 'insideBottom',
-                  offset: -5,
-                  style: { fontSize: 10 }
-                }}
-              />
-              <YAxis 
-                type="category" 
-                dataKey="registration" 
-                axisLine={false}
-                tickLine={false}
-                width={70} 
-                tick={{ fontSize: 11, fontWeight: 500 }}
-              />
-              <Tooltip content={(props) => <CustomTooltip {...props} />} />
-              <Bar 
-                dataKey="fuelLiters" 
-                name="Fuel Consumed"
-                label={{
-                  position: 'right',
-                  formatter: (value: number) => `${value.toLocaleString()} L`,
-                  fill: '#6B7280',
-                  fontSize: 11,
-                  fontWeight: 500
-                }}
-                barSize={32}
-              >
-                {chartData.map((entry, index) => (
-                  <Cell 
-                    key={`cell-${index}`} 
-                    fill={CHART_COLORS[index % CHART_COLORS.length]}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-      
-      {chartData.length === 0 && (
-        <div className="text-center py-6 text-gray-500 bg-gray-50 rounded-lg">
-          No fuel consumption data available for the selected period
-        </div>
-      )}
-    </div>
+    <ChartWrapper dataLength={chartData.length} scrollDirection="y">
+      <BarChart
+        data={chartData}
+        layout="vertical"
+        margin={{ top: 10, right: 30, left: 70, bottom: 10 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" horizontal={true} vertical={false} />
+        <XAxis
+          type="number"
+          axisLine={false}
+          tickLine={false}
+          domain={[0, 'auto']}
+          tick={{ fontSize: 10 }}
+          label={{
+            value: 'Liters',
+            position: 'insideBottom',
+            offset: -5,
+            style: { fontSize: 10 }
+          }}
+        />
+        <YAxis
+          type="category"
+          dataKey="registration"
+          axisLine={false}
+          tickLine={false}
+          width={70}
+          tick={{ fontSize: 11, fontWeight: 500 }}
+        />
+        <Tooltip content={(props) => <CustomTooltip {...props} />} />
+        <Bar
+          dataKey="fuelLiters"
+          name="Fuel Consumed"
+          label={{
+            position: 'right',
+            formatter: (value: number) => `${value.toLocaleString()} L`,
+            fill: '#6B7280',
+            fontSize: 11,
+            fontWeight: 500
+          }}
+          barSize={32}
+        >
+          {chartData.map((entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={CHART_COLORS[index % CHART_COLORS.length]}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ChartWrapper>
   );
 };
 

--- a/src/components/trips/charts/MonthlyFuelConsumptionChart.tsx
+++ b/src/components/trips/charts/MonthlyFuelConsumptionChart.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
 import { Trip } from '../../../types';
 import { parseISO, isValid, isWithinInterval, format, isBefore } from 'date-fns';
+import ChartWrapper from './ChartWrapper';
 
 interface MonthlyFuelConsumptionChartProps {
   trips: Trip[];
@@ -89,65 +90,53 @@ const MonthlyFuelConsumptionChart: React.FC<MonthlyFuelConsumptionChartProps> = 
   };
 
   return (
-    <div className="space-y-2">      
-      <div className="h-72 overflow-x-auto">
-        <div className="min-w-[600px] h-full">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={chartData}
-              margin={{ top: 15, right: 20, left: 10, bottom: 15 }}
-            >
-              <defs>
-                <linearGradient id="fuelGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#4CAF50" stopOpacity={0.9} />
-                  <stop offset="100%" stopColor="#0277BD" stopOpacity={0.9} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis 
-                dataKey="month" 
-                tick={{ fontSize: 11, fontWeight: 500 }}
-                tickLine={false}
-              />
-              <YAxis 
-                tickLine={false}
-                axisLine={false}
-                tick={{ fontSize: 10 }}
-                label={{ 
-                  value: 'Liters', 
-                  angle: -90, 
-                  position: 'insideLeft',
-                  style: { textAnchor: 'middle', fontSize: 10 }
-                }}
-              />
-              <Tooltip content={(props) => <CustomTooltip {...props} />} />
-              <Bar 
-                dataKey="fuelLiters" 
-                name="Fuel Consumed"
-                label={{ 
-                  position: 'top',
-                  formatter: (value: number) => `${value.toLocaleString()} L`,
-                  fontSize: 10,
-                  fontWeight: 500,
-                  fill: '#4B5563',
-                  dy: -4
-                }}
-                barSize={30} 
-                fill="url(#fuelGradient)"
-                radius={[4, 4, 0, 0]}
-              >
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-      
-      {chartData.length === 0 && (
-        <div className="text-center py-6 text-gray-500 bg-gray-50 rounded-lg">
-          No fuel consumption data available for the selected period
-        </div>
-      )}
-    </div>
+    <ChartWrapper dataLength={chartData.length}>
+      <BarChart
+        data={chartData}
+        margin={{ top: 15, right: 20, left: 10, bottom: 15 }}
+      >
+        <defs>
+          <linearGradient id="fuelGradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#4CAF50" stopOpacity={0.9} />
+            <stop offset="100%" stopColor="#0277BD" stopOpacity={0.9} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis
+          dataKey="month"
+          tick={{ fontSize: 11, fontWeight: 500 }}
+          tickLine={false}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tick={{ fontSize: 10 }}
+          label={{
+            value: 'Liters',
+            angle: -90,
+            position: 'insideLeft',
+            style: { textAnchor: 'middle', fontSize: 10 }
+          }}
+        />
+        <Tooltip content={(props) => <CustomTooltip {...props} />} />
+        <Bar
+          dataKey="fuelLiters"
+          name="Fuel Consumed"
+          label={{
+            position: 'top',
+            formatter: (value: number) => `${value.toLocaleString()} L`,
+            fontSize: 10,
+            fontWeight: 500,
+            fill: '#4B5563',
+            dy: -4
+          }}
+          barSize={30}
+          fill="url(#fuelGradient)"
+          radius={[4, 4, 0, 0]}
+        >
+        </Bar>
+      </BarChart>
+    </ChartWrapper>
   );
 };
 


### PR DESCRIPTION
## Summary
- create reusable ChartWrapper for shared chart layout
- use ChartWrapper in FuelConsumedByVehicleChart and MonthlyFuelConsumptionChart

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab65d7e5fc8324b22fefdda63e2426