### PR TITLE
Optimize vehicle stats aggregation using trip data

### DIFF
--- a/src/pages/VehiclesPage.tsx
+++ b/src/pages/VehiclesPage.tsx
@@ -13,7 +13,7 @@ interface VehicleWithStats extends Vehicle {
 
 import {
   getVehicles,
-  getVehicleStats,
+  getAllVehicleStats,
   createVehicle,
   getTrips,
   getDrivers,
@@ -122,13 +122,17 @@ const VehiclesPage: React.FC = () => {
         setDrivers(driversArray);
         setTrips(tripsArray);
 
-        // Fetch stats for each vehicle
-        const vehiclesWithStats = await Promise.all(
-          vehiclesArray.map(async (vehicle) => {
-            const stats = await getVehicleStats(vehicle.id);
-            return { ...vehicle, stats, selected: false };
-          })
-        );
+        const statsMap = await getAllVehicleStats(tripsArray);
+        const vehiclesWithStats = vehiclesArray.map((vehicle) => ({
+          ...vehicle,
+          stats:
+            statsMap[vehicle.id] ?? {
+              totalTrips: 0,
+              totalDistance: 0,
+              averageKmpl: undefined,
+            },
+          selected: false,
+        }));
 
         setVehicles(vehiclesWithStats);
 


### PR DESCRIPTION
## Summary
- add `getAllVehicleStats` helper to compute trip totals per vehicle in one pass
- refactor `VehiclesPage` to use aggregated stats instead of per-vehicle queries

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68acb9fdbd2083249fbe40f09dce1c7b