### PR TITLE
chore: clean up destination import

### DIFF
--- a/src/components/trips/SearchableDestinationInput.tsx
+++ b/src/components/trips/SearchableDestinationInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { MapPin, Plus, Search, Building, MapIcon as Town, Globe, X } from 'lucide-react';
 import { loadGoogleMaps } from '../../utils/googleMapsLoader';
-import { getDestinations } from '../../utils/storage'; /* Added dark mode classes */
+import { getDestinations } from '../../utils/storage';
 import { Destination } from '../../types';
 import Button from '../ui/Button';
 import Input from '../ui/Input';


### PR DESCRIPTION
## Summary
- remove leftover dark mode comment from `SearchableDestinationInput` import

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68accade81b88324be7d3a5762c9a163