### PR TITLE
chore: remove unused destination ids variable

### DIFF
--- a/src/pages/TripDetailsPage.tsx
+++ b/src/pages/TripDetailsPage.tsx
@@ -111,9 +111,6 @@ const TripDetailsPage: React.FC = () => {
   const handleUpdate = async (data: TripFormData) => {
     if (!trip) return;
     
-    // Extract destination IDs from the destination objects
-    const destinationIds = data.destinations;
-    
     setIsSubmitting(true);
     
     try {


### PR DESCRIPTION
## Summary
- remove unused destinationIds variable from TripDetailsPage update handler

## Testing
- `npm test`
- `npm run lint` *(warnings: React Hook dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68af066d596c83249dbd51d504df049d