### PR TITLE
feat: add trip identifiers to Trip interface

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -280,6 +280,8 @@ export interface Trip {
   vehicle_id: string;
   driver_id: string;
   warehouse_id: string;
+  trip_serial_number?: string;
+  manual_trip_id?: string;
   destinations: string[];
   trip_start_date: string;
   trip_end_date: string;
@@ -302,7 +304,6 @@ export interface Trip {
   fuel_bill_url?: string;
   is_return_trip?: boolean;
   advance_amount?: number; // New field for advance amount
-  fuel_rate_per_liter?: number;
   created_at: string;
   updated_at: string;
 


### PR DESCRIPTION
## Summary
- add optional trip_serial_number and manual_trip_id to Trip interface
- remove duplicate fuel_rate_per_liter property

## Testing
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af067185cc8324a832bbac37840879