### PR TITLE
feat: dynamically import papaparse

### DIFF
--- a/src/pages/admin/AdminTripsPage.tsx
+++ b/src/pages/admin/AdminTripsPage.tsx
@@ -404,7 +404,7 @@ const AdminTripsPage: React.FC = () => {
     setDatePreset('last30');
   };
 
-  const handleExport = (options: ExportOptions) => {
+  const handleExport = async (options: ExportOptions) => {
     // Filter trips based on export options
     let filteredTrips = trips;
 
@@ -475,12 +475,12 @@ const AdminTripsPage: React.FC = () => {
       XLSX.utils.book_append_sheet(wb, ws, 'Trips');
       XLSX.writeFile(wb, 'trips-export.xlsx');
     } else {
-      const csv = generateCSV(exportData, {});
+      const csv = await generateCSV(exportData, {});
       downloadCSV('trips-export.csv', csv);
     }
   };
 
-  const handleDownloadFormat = () => {
+  const handleDownloadFormat = async () => {
     const sampleData = [{
       'Trip ID': 'T0001',
       'Vehicle Registration': 'CG-04-XX-1234',
@@ -498,7 +498,7 @@ const AdminTripsPage: React.FC = () => {
       'Notes': 'Regular delivery trip'
     }];
 
-    const csv = generateCSV(sampleData, {});
+    const csv = await generateCSV(sampleData, {});
     downloadCSV('trips-import-format.csv', csv);
   };
 

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -1,8 +1,7 @@
-import Papa from 'papaparse';
-
-export const parseCSV = (file: File): Promise<any[]> => {
+export const parseCSV = async (file: File): Promise<any[]> => {
+  const Papa = await import('papaparse');
   return new Promise((resolve, reject) => {
-    Papa.parse(file, {
+    Papa.default.parse(file, {
       header: true,
       skipEmptyLines: true,
       complete: (results) => {
@@ -19,7 +18,8 @@ export const parseCSV = (file: File): Promise<any[]> => {
   });
 };
 
-export const generateCSV = (data: any[], headers: { [key: string]: string }): string => {
+export const generateCSV = async (data: any[], headers: { [key: string]: string }): Promise<string> => {
+  const Papa = await import('papaparse');
   const csvData = data.map(row => {
     const newRow: { [key: string]: any } = {};
     Object.entries(headers).forEach(([key, label]) => {
@@ -28,7 +28,7 @@ export const generateCSV = (data: any[], headers: { [key: string]: string }): st
     return newRow;
   });
 
-  return Papa.unparse(csvData);
+  return Papa.default.unparse(csvData);
 };
 
 export const downloadCSV = (filename: string, data: string) => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -340,7 +340,7 @@ export const exportVehicleData = async (): Promise<void> => {
     };
     
     // Generate CSV
-    const csvData = generateCSV(vehicles, headers);
+    const csvData = await generateCSV(vehicles, headers);
     
     // Download CSV
     const fileName = `vehicles_export_${new Date().toISOString().split('T')[0]}.csv`;


### PR DESCRIPTION
## Summary
- dynamically import papaparse only when parsing or generating CSVs
- update CSV export handlers to await dynamic imports
- ensure vehicle data export uses async CSV generation

## Testing
- `npm test` *(fails: Failed to load url /workspace/Fleet-Management-System---Trip-Sheet-Module3/src/testSetup.ts)*
- `npm run lint` *(fails: 1 error, 20 warnings)*
- `node -e "const {JSDOM} = require('jsdom'); const {window} = new JSDOM(''); global.File = window.File; global.FileReader = window.FileReader; global.Blob = window.Blob; import('./.tmp/csvParser.js').then(async m => { const csv=await m.generateCSV([{foo1:'bar', foo2:'baz'}], {foo1:'Foo', foo2:'Bar'}); console.log('CSV:', csv); const file=new File([csv],'test.csv',{type:'text/csv'}); const data=await m.parseCSV(file); console.log('Data:', data); })"`

------
https://chatgpt.com/codex/tasks/task_e_68b5d1c7822483248fc0b65341a7fb76