### PR TITLE
chore: remove unused rbac scan script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "scan:rbac": "node scripts/find-rbac-refs.mjs",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- remove obsolete `scan:rbac` script from package.json

## Testing
- `npm run`
- `npm test` *(fails: Failed to load url /workspace/Fleet-Management-System---Trip-Sheet-Module3/src/testSetup.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d42a5be48324af3003433dbf495b