### PR TITLE
chore: remove unused router imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,7 @@ import {
   BrowserRouter as Router,
   Routes,
   Route,
-  Navigate,
-  Outlet,
-  useNavigate,
+  Navigate
 } from "react-router-dom";
 import { Session } from "@supabase/supabase-js";
 import { supabase, testSupabaseConnection } from "./utils/supabaseClient";


### PR DESCRIPTION
## Summary
- remove unused `Outlet` and `useNavigate` imports from App component

## Testing
- `npm run lint` *(fails: Unnecessary try/catch wrapper no-useless-catch)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d97fbe9483249aab15ed5a27da91