### PR TITLE
Centralize validated env config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "react-toastify": "^9.1.3",
         "recharts": "^2.10.3",
         "tailwind-merge": "^3.3.1",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -7694,6 +7695,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react-toastify": "^9.1.3",
     "recharts": "^2.10.3",
     "tailwind-merge": "^3.3.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-router-dom";
 import { Session } from "@supabase/supabase-js";
 import { supabase, testSupabaseConnection } from "./utils/supabaseClient";
+import config from "./utils/config";
 import ErrorBoundary from "./components/ErrorBoundary";
 import LoadingScreen from "./components/LoadingScreen";
 import { ToastContainer } from 'react-toastify';
@@ -61,7 +62,7 @@ const App: React.FC = () => {
         
         if (error) {
           if (isNetworkError(error)) {
-            if (import.meta.env.DEV) console.warn('Network error getting session, continuing without session');
+            if (config.isDev) console.warn('Network error getting session, continuing without session');
             setSession(null);
           } else {
             console.error('Session error:', error);

--- a/src/components/admin/reminders/ReminderManager.tsx
+++ b/src/components/admin/reminders/ReminderManager.tsx
@@ -6,6 +6,7 @@ import ContactList from './ContactList';
 import TemplateTable from './TemplateTable';
 import AddTemplateForm from './AddTemplateForm';
 import { ReminderContact, ReminderTemplate, ReminderContactFormData } from '../../../types/reminders';
+import config from '../../../utils/config';
 import { 
   getReminderContacts, 
   createReminderContact, 
@@ -59,7 +60,7 @@ const ReminderManager: React.FC = () => {
           const tempId = `temp-${Date.now()}`;
           photoUrl = await uploadContactPhoto(data.photo, tempId);
         } catch (photoError) {
-          if (import.meta.env.DEV) console.warn('Photo upload failed, proceeding without photo:', photoError);
+          if (config.isDev) console.warn('Photo upload failed, proceeding without photo:', photoError);
           toast.warning('Contact created successfully, but photo upload failed. Please ensure the storage bucket exists.');
         }
       }
@@ -86,7 +87,7 @@ const ReminderManager: React.FC = () => {
             newContact.photo_url = updatedPhotoUrl;
           }
         } catch (photoError) {
-          if (import.meta.env.DEV) console.warn('Photo update failed, but contact was created:', photoError);
+          if (config.isDev) console.warn('Photo update failed, but contact was created:', photoError);
         }
       }
 
@@ -114,7 +115,7 @@ const ReminderManager: React.FC = () => {
             photoUrl = uploadedPhotoUrl;
           }
         } catch (photoError) {
-          if (import.meta.env.DEV) console.warn('Photo upload failed during update:', photoError);
+          if (config.isDev) console.warn('Photo upload failed during update:', photoError);
           toast.warning('Contact updated successfully, but photo upload failed. Please ensure the storage bucket exists.');
         }
       }

--- a/src/components/maps/GoogleMap.tsx
+++ b/src/components/maps/GoogleMap.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Loader } from '@googlemaps/js-api-loader';
 import { AlertTriangle } from 'lucide-react';
+import config from '../../utils/config';
 
 interface GoogleMapProps {
   waypoints: Array<{ lat: number; lng: number }>;
@@ -13,7 +14,7 @@ const GoogleMap: React.FC<GoogleMapProps> = ({ waypoints, className = 'h-64' }) 
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+    const apiKey = config.googleMapsApiKey;
 
     if (!apiKey) {
       setError('Google Maps API key is missing. Please check your environment variables.');

--- a/src/components/maps/TripMap.tsx
+++ b/src/components/maps/TripMap.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Loader } from '@googlemaps/js-api-loader';
 import { Warehouse, Destination } from '../../types';
 import { AlertTriangle } from 'lucide-react';
+import config from '../../utils/config';
 
 interface TripMapProps {
   warehouse?: Warehouse;
@@ -44,7 +45,7 @@ const TripMap: React.FC<TripMapProps> = ({
   };
 
   useEffect(() => {
-    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+    const apiKey = config.googleMapsApiKey;
 
     if (!apiKey) {
       setError('Google Maps API key is missing');

--- a/src/components/shared/DocumentUploader.tsx
+++ b/src/components/shared/DocumentUploader.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { Upload, CheckCircle, XCircle, RefreshCw, Eye, Download } from 'lucide-react';
 import { cn } from '../../utils/cn';
 import { uploadVehicleDocument, uploadDriverDocument } from '../../utils/supabaseStorage';
+import config from '../../utils/config';
 
 interface DocumentUploaderProps {
   label: string;
@@ -242,7 +243,7 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({
                     onClick={(e) => {
                       e.stopPropagation();
                       // In a real implementation, you'd generate a signed URL and open it
-                      if (import.meta.env.DEV) console.log('View document:', path);
+                      if (config.isDev) console.log('View document:', path);
                     }}
                   >
                     <Eye className="h-4 w-4" />

--- a/src/components/trips/TripCard.tsx
+++ b/src/components/trips/TripCard.tsx
@@ -6,6 +6,7 @@ import { getWarehouse, getDestination } from '../../utils/storage';
 import { truncateString } from '../../utils/format';
 import { uploadFilesAndGetPublicUrls } from '../../utils/supabaseStorage';
 import { toast } from 'react-toastify';
+import config from '../../utils/config';
 
 interface TripCardProps {
   trip: Trip;
@@ -55,7 +56,7 @@ const TripCard: React.FC<TripCardProps> = ({ trip, vehicle, driver, onClick, onP
                 try {
                   return await getDestination(id);
                 } catch (error) {
-                  if (import.meta.env.DEV) console.warn(`Destination ${id} not found or error fetching:`, error);
+                  if (config.isDev) console.warn(`Destination ${id} not found or error fetching:`, error);
                   return null;
                 }
               })

--- a/src/components/trips/TripForm.tsx
+++ b/src/components/trips/TripForm.tsx
@@ -18,6 +18,7 @@ import MaterialSelector from './MaterialSelector';
 import RouteAnalysis from './RouteAnalysis';
 import FuelRateSelector from './FuelRateSelector';
 import CollapsibleSection from '../ui/CollapsibleSection';
+import config from '../../utils/config';
 import {
   Truck,
   User,
@@ -353,7 +354,7 @@ const TripForm: React.FC<TripFormProps> = ({
             const alerts = await analyzeTripAndGenerateAlerts(tempTripData, analysis, trips);
             setAiAlerts(alerts);
           } else {
-            if (import.meta.env.DEV) console.warn('Cannot calculate route deviation: invalid distance values', { standardDistance, actualDistance });
+            if (config.isDev) console.warn('Cannot calculate route deviation: invalid distance values', { standardDistance, actualDistance });
           }
         }
       } catch (error) {

--- a/src/components/trips/charts/AverageMileagePerVehicleChart.tsx
+++ b/src/components/trips/charts/AverageMileagePerVehicleChart.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { Trip, Vehicle } from '../../../types';
 import { parseISO, isValid, isWithinInterval, format, isBefore } from 'date-fns';
+import config from '../../../utils/config';
 
 interface AverageMileagePerVehicleChartProps {
   trips: Trip[];
@@ -20,7 +21,7 @@ const AverageMileagePerVehicleChart: React.FC<AverageMileagePerVehicleChartProps
     
     // Safety check for date range validity
     if (!isValid(dateRange.start) || !isValid(dateRange.end) || !isBefore(dateRange.start, dateRange.end)) {
-      if (import.meta.env.DEV) console.warn('Invalid date range:', dateRange);
+      if (config.isDev) console.warn('Invalid date range:', dateRange);
       return [];
     }
 
@@ -34,7 +35,7 @@ const AverageMileagePerVehicleChart: React.FC<AverageMileagePerVehicleChartProps
         
         return isWithinInterval(tripDate, dateRange);
       } catch (error) {
-        if (import.meta.env.DEV) console.warn('Error filtering trip by date:', error);
+        if (config.isDev) console.warn('Error filtering trip by date:', error);
         return false;
       }
     });

--- a/src/components/trips/charts/FuelConsumedByVehicleChart.tsx
+++ b/src/components/trips/charts/FuelConsumedByVehicleChart.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { Trip, Vehicle } from '../../../types';
 import { parseISO, isValid, isWithinInterval, format, isBefore } from 'date-fns';
+import config from '../../../utils/config';
 
 interface FuelConsumedByVehicleChartProps {
   trips: Trip[];
@@ -25,7 +26,7 @@ const FuelConsumedByVehicleChart: React.FC<FuelConsumedByVehicleChartProps> = ({
 
     // Safety check for date range validity
     if (!isValid(dateRange.start) || !isValid(dateRange.end) || !isBefore(dateRange.start, dateRange.end)) {
-      if (import.meta.env.DEV) console.warn('Invalid date range:', dateRange);
+      if (config.isDev) console.warn('Invalid date range:', dateRange);
       return [];
     }
 
@@ -39,7 +40,7 @@ const FuelConsumedByVehicleChart: React.FC<FuelConsumedByVehicleChartProps> = ({
         
         return isWithinInterval(tripDate, dateRange);
       } catch (error) {
-        if (import.meta.env.DEV) console.warn('Error filtering trip by date:', error);
+        if (config.isDev) console.warn('Error filtering trip by date:', error);
         return false;
       }
     });

--- a/src/components/trips/charts/MonthlyFuelConsumptionChart.tsx
+++ b/src/components/trips/charts/MonthlyFuelConsumptionChart.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { Trip } from '../../../types';
 import { parseISO, isValid, isWithinInterval, format, isBefore } from 'date-fns';
+import config from '../../../utils/config';
 
 interface MonthlyFuelConsumptionChartProps {
   trips: Trip[];
@@ -18,7 +19,7 @@ const MonthlyFuelConsumptionChart: React.FC<MonthlyFuelConsumptionChartProps> = 
     
     // Safety check for date range validity
     if (!isValid(dateRange.start) || !isValid(dateRange.end) || !isBefore(dateRange.start, dateRange.end)) {
-      if (import.meta.env.DEV) console.warn('Invalid date range:', dateRange);
+      if (config.isDev) console.warn('Invalid date range:', dateRange);
       return [];
     }
 
@@ -32,7 +33,7 @@ const MonthlyFuelConsumptionChart: React.FC<MonthlyFuelConsumptionChartProps> = 
         
         return isWithinInterval(tripDate, dateRange);
       } catch (error) {
-        if (import.meta.env.DEV) console.warn('Error filtering trip by date:', error);
+        if (config.isDev) console.warn('Error filtering trip by date:', error);
         return false;
       }
     });

--- a/src/components/ui/SpeechToTextButton.tsx
+++ b/src/components/ui/SpeechToTextButton.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Mic, MicOff, Loader } from 'lucide-react';
+import config from '../../utils/config';
 
 interface SpeechToTextButtonProps {
   onTranscript: (text: string) => void;
@@ -49,7 +50,7 @@ const SpeechToTextButton: React.FC<SpeechToTextButtonProps> = ({
       };
     } else {
       setIsSupported(false);
-      if (import.meta.env.DEV) console.warn('Speech recognition is not supported in this browser');
+      if (config.isDev) console.warn('Speech recognition is not supported in this browser');
     }
 
     return () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import LoadingScreen from "./components/LoadingScreen";
 import { ThemeProvider } from "./utils/themeContext";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import config from "./utils/config";
 
 // Create a client
 const queryClient = new QueryClient({
@@ -53,7 +54,7 @@ setTimeout(() => {
             <App />
           </ErrorBoundary>
         </ThemeProvider>
-        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+        {config.isDev && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </StrictMode>
   );

--- a/src/pages/VehiclesPage.tsx
+++ b/src/pages/VehiclesPage.tsx
@@ -19,6 +19,7 @@ import {
   getDriverSummaries,
 } from "../utils/storage";
 import { supabase } from "../utils/supabaseClient";
+import config from "../utils/config";
 import { uploadVehicleDocument } from "../utils/supabaseStorage";
 import { format, parseISO, isValid } from "date-fns";
 import {
@@ -111,13 +112,13 @@ const VehiclesPage: React.FC = () => {
         const tripsArray = Array.isArray(tripsData) ? tripsData : [];
 
         // Debug: Log driver count and any missing assignments
-        if (import.meta.env.DEV) console.log('Fetched drivers count:', driversArray.length);
+        if (config.isDev) console.log('Fetched drivers count:', driversArray.length);
         const vehiclesWithDriverIds = vehiclesArray.filter(v => v.primary_driver_id);
         const missingDriverAssignments = vehiclesWithDriverIds.filter(v => 
           !driversArray.find(d => d.id === v.primary_driver_id)
         );
         if (missingDriverAssignments.length > 0) {
-          if (import.meta.env.DEV) console.warn('Vehicles with missing driver assignments:', missingDriverAssignments.map(v => ({
+          if (config.isDev) console.warn('Vehicles with missing driver assignments:', missingDriverAssignments.map(v => ({
             vehicle: v.registration_number,
             primary_driver_id: v.primary_driver_id
           })));

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+// Combine environment variables from Vite and Node.js for flexibility
+const rawEnv = {
+  ...(typeof import.meta !== 'undefined' ? (import.meta as any).env : {}),
+  ...process.env
+} as Record<string, string | boolean | undefined>;
+
+// Define schema for required environment variables
+const envSchema = z.object({
+  VITE_SUPABASE_URL: z.string().url({ message: 'VITE_SUPABASE_URL must be a valid URL' }),
+  VITE_SUPABASE_ANON_KEY: z.string().min(1, 'VITE_SUPABASE_ANON_KEY is required'),
+  VITE_GOOGLE_MAPS_API_KEY: z.string().min(1, 'VITE_GOOGLE_MAPS_API_KEY is required'),
+  MODE: z.string().optional(),
+  DEV: z.union([z.boolean(), z.string()]).optional(),
+});
+
+const parsed = envSchema.safeParse(rawEnv);
+if (!parsed.success) {
+  const message = parsed.error.errors
+    .map(err => `${err.path.join('.')}: ${err.message}`)
+    .join('; ');
+  throw new Error(`Invalid or missing environment variables: ${message}`);
+}
+
+const data = parsed.data;
+const isDev = data.MODE === 'development' || data.DEV === true || data.DEV === 'true';
+
+export const config = {
+  supabaseUrl: data.VITE_SUPABASE_URL,
+  supabaseAnonKey: data.VITE_SUPABASE_ANON_KEY,
+  googleMapsApiKey: data.VITE_GOOGLE_MAPS_API_KEY,
+  isDev,
+};
+
+export default config;

--- a/src/utils/googleMapsLoader.ts
+++ b/src/utils/googleMapsLoader.ts
@@ -1,13 +1,14 @@
 import { Loader } from '@googlemaps/js-api-loader';
+import config from './config';
 
-const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+const { googleMapsApiKey } = config;
 
-if (!GOOGLE_MAPS_API_KEY) {
+if (!googleMapsApiKey) {
   throw new Error('Google Maps API key is missing. Please check your .env file and ensure VITE_GOOGLE_MAPS_API_KEY is set.');
 }
 
 const loader = new Loader({
-  apiKey: GOOGLE_MAPS_API_KEY,
+  apiKey: googleMapsApiKey,
   version: 'weekly',
   libraries: ['places']
 });

--- a/src/utils/reminderService.ts
+++ b/src/utils/reminderService.ts
@@ -1,6 +1,7 @@
 import { supabase } from "./supabaseClient";
 import { ReminderContact, ReminderTemplate } from "../types/reminders";
 import { handleSupabaseError } from "./errors";
+import config from "./config";
 
 // Reminder Contacts CRUD operations
 export const getReminderContacts = async (): Promise<ReminderContact[]> => {
@@ -203,7 +204,7 @@ export const uploadContactPhoto = async (
   contactId: string
 ): Promise<string | undefined> => {
   if (!file || !file.name) {
-    if (import.meta.env.DEV) console.warn("No photo uploaded — skipping uploadContactPhoto.");
+    if (config.isDev) console.warn("No photo uploaded — skipping uploadContactPhoto.");
     return undefined;
   }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabaseClient';
 import { isNetworkError, handleNetworkError } from './supabaseClient';
+import config from './config';
 import {
   Trip,
   TripFormData,
@@ -45,7 +46,7 @@ export async function getUserData() {
     if (error) {
       // Handle network errors gracefully
       if (isNetworkError(error)) {
-        if (import.meta.env.DEV) console.warn('Network error getting user data, returning null user');
+        if (config.isDev) console.warn('Network error getting user data, returning null user');
         return { user: null, error: null };
       }
       handleSupabaseError('get user data', error);
@@ -56,7 +57,7 @@ export async function getUserData() {
   } catch (error) {
     // Handle network errors gracefully
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error getting user data, returning null user');
+      if (config.isDev) console.warn('Network error getting user data, returning null user');
       return { user: null, error: null };
     }
     handleSupabaseError('get user data', error);
@@ -71,7 +72,7 @@ export const getVehicles = async (): Promise<Vehicle[]> => {
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for vehicles, returning empty array');
+        if (config.isDev) console.warn('Network error fetching user for vehicles, returning empty array');
         return [];
       }
       handleSupabaseError('get user for vehicles', userError);
@@ -97,7 +98,7 @@ export const getVehicles = async (): Promise<Vehicle[]> => {
     return data || [];
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error fetching user for vehicles, returning empty array');
+      if (config.isDev) console.warn('Network error fetching user for vehicles, returning empty array');
       return [];
     }
     handleSupabaseError('get user for vehicles', error);
@@ -378,7 +379,7 @@ export const getDrivers = async (): Promise<Driver[]> => {
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for drivers, returning empty array');
+        if (config.isDev) console.warn('Network error fetching user for drivers, returning empty array');
         return [];
       }
       handleSupabaseError('get user for drivers', userError);
@@ -404,7 +405,7 @@ export const getDrivers = async (): Promise<Driver[]> => {
     return data || [];
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error fetching user for drivers, returning empty array');
+      if (config.isDev) console.warn('Network error fetching user for drivers, returning empty array');
       return [];
     }
     handleSupabaseError('get user for drivers', error);
@@ -418,7 +419,7 @@ export const getDriverSummaries = async (): Promise<DriverSummary[]> => {
 
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for driver summaries, returning empty array');
+        if (config.isDev) console.warn('Network error fetching user for driver summaries, returning empty array');
         return [];
       }
       handleSupabaseError('get user for driver summaries', userError);
@@ -444,7 +445,7 @@ export const getDriverSummaries = async (): Promise<DriverSummary[]> => {
     return data || [];
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error fetching user for driver summaries, returning empty array');
+      if (config.isDev) console.warn('Network error fetching user for driver summaries, returning empty array');
       return [];
     }
     handleSupabaseError('get user for driver summaries', error);
@@ -554,7 +555,7 @@ export const deleteDriver = async (id: string): Promise<boolean> => {
 // Photo upload function for drivers
 export const uploadDriverPhoto = async (file: File, driverId: string): Promise<string | undefined> => {
   if (!file || !file.name) { // ⚠️ Confirm field refactor here
-    if (import.meta.env.DEV) console.warn('No photo uploaded — skipping uploadDriverPhoto.'); // ⚠️ Confirm field refactor here
+    if (config.isDev) console.warn('No photo uploaded — skipping uploadDriverPhoto.'); // ⚠️ Confirm field refactor here
     return undefined;
   }
 
@@ -585,7 +586,7 @@ export const getTrips = async (): Promise<Trip[]> => {
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for trips, returning empty array');
+        if (config.isDev) console.warn('Network error fetching user for trips, returning empty array');
         return [];
       }
       handleSupabaseError('get user for trips', userError);
@@ -611,7 +612,7 @@ export const getTrips = async (): Promise<Trip[]> => {
     return data || [];
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error fetching user for trips, returning empty array');
+      if (config.isDev) console.warn('Network error fetching user for trips, returning empty array');
       return [];
     }
     handleSupabaseError('get user for trips', error);
@@ -668,7 +669,7 @@ export const createTrip = async (tripData: Omit<Trip, 'id'>): Promise<Trip | nul
       userId
     );
 
-    if (import.meta.env.DEV) console.log("Submitting trip with payload:", payload);
+    if (config.isDev) console.log("Submitting trip with payload:", payload);
     const { data, error } = await supabase
       .from('trips')
       .insert(payload)
@@ -729,7 +730,7 @@ export const getWarehouses = async (): Promise<Warehouse[]> => {
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for warehouses, returning empty array');
+        if (config.isDev) console.warn('Network error fetching user for warehouses, returning empty array');
         return [];
       }
       handleSupabaseError('get user for warehouses', userError);
@@ -756,7 +757,7 @@ export const getWarehouses = async (): Promise<Warehouse[]> => {
     return data || [];
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error fetching user for warehouses, returning empty array');
+      if (config.isDev) console.warn('Network error fetching user for warehouses, returning empty array');
       return [];
     }
     handleSupabaseError('get user for warehouses', error);
@@ -786,7 +787,7 @@ export const getDestinations = async (): Promise<Destination[]> => {
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for destinations, returning empty array');
+        if (config.isDev) console.warn('Network error fetching user for destinations, returning empty array');
         return [];
       }
       handleSupabaseError('get user for destinations', userError);
@@ -813,7 +814,7 @@ export const getDestinations = async (): Promise<Destination[]> => {
     return data || [];
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error fetching user for destinations, returning empty array');
+      if (config.isDev) console.warn('Network error fetching user for destinations, returning empty array');
       return [];
     }
     handleSupabaseError('get user for destinations', error);
@@ -827,7 +828,7 @@ export const getDestination = async (id: string): Promise<Destination | null> =>
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for destination, returning null');
+        if (config.isDev) console.warn('Network error fetching user for destination, returning null');
         return null;
       }
       handleSupabaseError('get user for destination', userError);
@@ -861,7 +862,7 @@ export const getDestination = async (id: string): Promise<Destination | null> =>
     return data;
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error fetching destination, returning null');
+      if (config.isDev) console.warn('Network error fetching destination, returning null');
       return null;
     }
     handleSupabaseError('fetch destination', error);
@@ -875,7 +876,7 @@ export const getDestinationByAnyId = async (id: string): Promise<Destination | n
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for destination by any id, returning null');
+        if (config.isDev) console.warn('Network error fetching user for destination by any id, returning null');
         return null;
       }
       handleSupabaseError('get user for destination by any id', userError);
@@ -911,7 +912,7 @@ export const getDestinationByAnyId = async (id: string): Promise<Destination | n
     return data;
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error fetching destination by any id, returning null');
+      if (config.isDev) console.warn('Network error fetching destination by any id, returning null');
       return null;
     }
     handleSupabaseError('fetch destination by any id', error);
@@ -1035,7 +1036,7 @@ export const getAllVehicleStats = async (
 
       if (userError) {
         if (isNetworkError(userError)) {
-          if (import.meta.env.DEV) console.warn(
+          if (config.isDev) console.warn(
             'Network error fetching user for vehicle stats, returning empty object'
           );
           return {};
@@ -1099,7 +1100,7 @@ export const getAllVehicleStats = async (
     return result;
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn(
+      if (config.isDev) console.warn(
         'Network error calculating vehicle stats, returning empty object'
       );
       return {};
@@ -1115,7 +1116,7 @@ export const getVehicleStats = async (vehicleId: string): Promise<any> => {
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for vehicle stats, returning defaults');
+        if (config.isDev) console.warn('Network error fetching user for vehicle stats, returning defaults');
         return { totalTrips: 0, totalDistance: 0, averageKmpl: undefined };
       }
       handleSupabaseError('get user for vehicle stats', userError);
@@ -1160,7 +1161,7 @@ export const getVehicleStats = async (vehicleId: string): Promise<any> => {
     };
   } catch (error) {
     if (isNetworkError(error)) {
-      if (import.meta.env.DEV) console.warn('Network error calculating vehicle stats, returning defaults');
+      if (config.isDev) console.warn('Network error calculating vehicle stats, returning defaults');
       return { totalTrips: 0, totalDistance: 0, averageKmpl: undefined };
     }
     handleSupabaseError('calculate vehicle stats', error);
@@ -1294,7 +1295,7 @@ export const getLatestOdometer = async (vehicleId: string): Promise<{ value: num
     
     if (userError) {
       if (isNetworkError(userError)) {
-        if (import.meta.env.DEV) console.warn('Network error fetching user for odometer, returning default');
+        if (config.isDev) console.warn('Network error fetching user for odometer, returning default');
         return { value: 0, fromTrip: false };
       }
       handleSupabaseError('get user for odometer', userError);

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,18 +1,9 @@
 import { createClient } from "@supabase/supabase-js";
+import config from "./config";
 
-// Handle both Vite (browser) and Node.js environments
-const getEnvVar = (key: string): string | undefined => {
-  // Check if we're in a Vite environment (browser)
-  if (typeof import.meta !== "undefined" && import.meta.env) {
-    return import.meta.env[key];
-  }
-  // Fallback to Node.js environment
-  return process.env[key];
-};
-
-// Get environment variables with cross-environment support
-const supabaseUrl = getEnvVar("VITE_SUPABASE_URL");
-const supabaseAnonKey = getEnvVar("VITE_SUPABASE_ANON_KEY");
+// Load required environment variables from central config
+const supabaseUrl = config.supabaseUrl;
+const supabaseAnonKey = config.supabaseAnonKey;
 
 // Check if the environment variables are properly set
 const isValidUrl = (url: string | undefined): boolean => {
@@ -249,7 +240,7 @@ export const testSupabaseConnection = async (): Promise<boolean> => {
       return false;
     }
 
-    if (import.meta.env.DEV) console.log("Supabase connection test passed (database query)");
+    if (config.isDev) console.log("Supabase connection test passed (database query)");
     return true;
   } catch (error) {
     console.error("Supabase connection test error:", error);
@@ -271,7 +262,7 @@ export const testSupabaseConnection = async (): Promise<boolean> => {
 Current origin: ${window.location.origin}`);
     }
     
-    if (import.meta.env.DEV) console.log("Supabase connection test passed (auth check)");
+    if (config.isDev) console.log("Supabase connection test passed (auth check)");
     
     // Handle timeout errors
     if (error instanceof Error && error.message === 'REQUEST_TIMEOUT') {
@@ -323,7 +314,7 @@ export const isNetworkError = (error: any): boolean => {
 // Helper function to handle network errors gracefully
 export const handleNetworkError = (error: any, fallbackData: any = null) => {
   if (isNetworkError(error)) {
-    if (import.meta.env.DEV) console.warn('Network connectivity issue detected. Using fallback data or retrying...');
+    if (config.isDev) console.warn('Network connectivity issue detected. Using fallback data or retrying...');
     return { data: fallbackData, error: null };
   }
   return { data: null, error };


### PR DESCRIPTION
## Summary
- add `config` module that validates required environment variables with zod
- use config in Supabase and Google Maps utilities and replace direct `import.meta.env` access
- gate development-only logs through `config.isDev`

## Testing
- `npm test` *(fails: Failed to load url /workspace/Fleet-Management-System---Trip-Sheet-Module3/src/testSetup.ts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5dbd29acc8324b14ad6c78635c843