### PR TITLE
feat: centralize environment flags for debug gating

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,19 @@
+const env = (() => {
+  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.MODE) {
+    return import.meta.env.MODE as string;
+  }
+  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV) {
+    return process.env.NODE_ENV;
+  }
+  return 'development';
+})();
+
+export const isDev = env === 'development';
+export const isTest = env === 'test';
+export const isProd = env === 'production';
+
+export default {
+  isDev,
+  isTest,
+  isProd,
+};

--- a/src/pages/VehiclesPage.tsx
+++ b/src/pages/VehiclesPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import Layout from "../components/layout/Layout";
 import { Vehicle, Trip, DriverSummary } from "../types"; // Import the Vehicle interface
+import { isDev } from "../config/env";
 
 interface VehicleWithStats extends Vehicle {
   stats: {
@@ -111,13 +112,13 @@ const VehiclesPage: React.FC = () => {
         const tripsArray = Array.isArray(tripsData) ? tripsData : [];
 
         // Debug: Log driver count and any missing assignments
-        if (import.meta.env.DEV) console.log('Fetched drivers count:', driversArray.length);
+        if (isDev) console.log('Fetched drivers count:', driversArray.length);
         const vehiclesWithDriverIds = vehiclesArray.filter(v => v.primary_driver_id);
         const missingDriverAssignments = vehiclesWithDriverIds.filter(v => 
           !driversArray.find(d => d.id === v.primary_driver_id)
         );
         if (missingDriverAssignments.length > 0) {
-          if (import.meta.env.DEV) console.warn('Vehicles with missing driver assignments:', missingDriverAssignments.map(v => ({
+          if (isDev) console.warn('Vehicles with missing driver assignments:', missingDriverAssignments.map(v => ({
             vehicle: v.registration_number,
             primary_driver_id: v.primary_driver_id
           })));

--- a/src/utils/reminderService.ts
+++ b/src/utils/reminderService.ts
@@ -1,4 +1,5 @@
 import { supabase } from "./supabaseClient";
+import { isDev } from "../config/env";
 import { ReminderContact, ReminderTemplate } from "../types/reminders";
 import { handleSupabaseError } from "./errors";
 
@@ -203,7 +204,7 @@ export const uploadContactPhoto = async (
   contactId: string
 ): Promise<string | undefined> => {
   if (!file || !file.name) {
-    if (import.meta.env.DEV) console.warn("No photo uploaded — skipping uploadContactPhoto.");
+    if (isDev) console.warn("No photo uploaded — skipping uploadContactPhoto.");
     return undefined;
   }
 

--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { isDev, isProd } from "../config/env";
 
 // Handle both Vite (browser) and Node.js environments
 const getEnvVar = (key: string): string | undefined => {
@@ -163,12 +164,19 @@ const createMockClient = () => {
 // Create the Supabase client with enhanced error handling
 const createSupabaseClient = () => {
   if (!isConfigured) {
+    if (isProd) {
+      throw new Error(
+        "Supabase is not properly configured in production environment."
+      );
+    }
     console.error("Supabase is not properly configured. Using mock client.");
     console.error("Environment variables:", {
       VITE_SUPABASE_URL: supabaseUrl,
       VITE_SUPABASE_ANON_KEY: supabaseAnonKey ? "Present" : "Missing",
     });
-    console.error("Please ensure you have copied .env.example to .env and filled in your actual Supabase credentials");
+    console.error(
+      "Please ensure you have copied .env.example to .env and filled in your actual Supabase credentials"
+    );
     return createMockClient() as any;
   }
 
@@ -249,7 +257,7 @@ export const testSupabaseConnection = async (): Promise<boolean> => {
       return false;
     }
 
-    if (import.meta.env.DEV) console.log("Supabase connection test passed (database query)");
+    if (isDev) console.log("Supabase connection test passed (database query)");
     return true;
   } catch (error) {
     console.error("Supabase connection test error:", error);
@@ -271,7 +279,7 @@ export const testSupabaseConnection = async (): Promise<boolean> => {
 Current origin: ${window.location.origin}`);
     }
     
-    if (import.meta.env.DEV) console.log("Supabase connection test passed (auth check)");
+    if (isDev) console.log("Supabase connection test passed (auth check)");
     
     // Handle timeout errors
     if (error instanceof Error && error.message === 'REQUEST_TIMEOUT') {
@@ -323,7 +331,7 @@ export const isNetworkError = (error: any): boolean => {
 // Helper function to handle network errors gracefully
 export const handleNetworkError = (error: any, fallbackData: any = null) => {
   if (isNetworkError(error)) {
-    if (import.meta.env.DEV) console.warn('Network connectivity issue detected. Using fallback data or retrying...');
+    if (isDev) console.warn('Network connectivity issue detected. Using fallback data or retrying...');
     return { data: fallbackData, error: null };
   }
   return { data: null, error };


### PR DESCRIPTION
## Summary
- add config helpers exposing `isDev`, `isTest`, and `isProd`
- use env flags to restrict debug logs and network warnings
- prevent mock Supabase client from being used in production

## Testing
- `npm test` *(fails: Failed to load url src/testSetup.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b5df011848832489fcc87417afadfe